### PR TITLE
Adds namespaces support for Yaf`s skeleton class generator

### DIFF
--- a/tools/yaf.php
+++ b/tools/yaf.php
@@ -1,15 +1,17 @@
 <?php
 /**
  * Yaf Classes signature generator
- * 
+ *
  * @author  Laruence
  * @date    2012-07-21 13:46
- * @version $Id$ 
-*/
+ * @version $Id$
+ */
 
+$useNamespace = (bool) ini_get("yaf.use_namespace");
+$yafClassPrefix = sprintf("Yaf%s", $useNamespace ? "\\" : "_");
 $classes = get_declared_classes();
 foreach ($classes as $key => $value) {
-    if (strncasecmp($value, "Yaf_", 3)) {
+    if (strncasecmp($value, $yafClassPrefix, 4)) {
         unset($classes[$key]);
     }
 }
@@ -17,117 +19,151 @@ foreach ($classes as $key => $value) {
 echo "<?php\n";
 
 foreach ($classes as $class_name) {
-     $class = new ReflectionClass($class_name);
-     $indent  = "";
+    $class = new ReflectionClass($class_name);
+    $indent  = "";
 
-     if ($class->isFinal()) {
-         echo "final ";
-     }
+    if ($useNamespace && false !== ($backslash = strrpos($class_name, "\\"))) {
+        $namespaceName  = substr($class_name, 0, $backslash);
+        $class_name = substr($class_name, $backslash + 1);
+        echo "namespace ", $namespaceName, " {\n";
 
-     if ($class->isAbstract()) {
-         echo "abstract ";
-     }
+        $indent = "\t";
+    }
 
-     if ($class->isInterface()) {
-         echo "Interface ", $class_name;
-     } else {
-         echo "class ", $class_name;
-     }
+    $classAttributes = "";
 
-     /* parent */
-     $parent = $class->getParentClass();
-     if ($parent) {
-         echo " extends ", $parent->getName();
-     }
+    if ($class->isInterface()) {
+        $classAttributes .= "interface ";
+    } else {
+        if ($class->isFinal()) {
+            $classAttributes .= "final ";
+        }
 
-     /* interface */
-     $interfaces = $class->getInterfaceNames();
-     if (count($interfaces)) {
-         echo " implements ", join(", ", $interfaces);
-     }
-     echo " { \n";
+        if ($class->isAbstract()) {
+            $classAttributes .= "abstract ";
+        }
 
-     $indent .= "\t";
-     /* constants */
-     echo $indent, "/* constants */\n";
-     $constatnts = $class->getConstants();
-     foreach ($constatnts as $k => $v) {
-         echo $indent, "const ", $k , " = ", $v , ";\n";
-     }
-     echo "\n";
+        $classAttributes .= "class ";
+    }
 
-     /* properties */
-     echo $indent, "/* properties */\n";
-     $properties = $class->getProperties();
-     $values     = $class->getDefaultProperties();
-     foreach ($properties as $p) {
-         echo $indent;
-         if ($p->isStatic()) {
-             echo "static ";
-         }
+    echo $indent, $classAttributes, $class_name;
 
-         if ($p->isPublic()) {
-             echo "public ";
-         } else if ($p->isProtected()) {
-             echo "protected ";
-         } else {
-             echo "private ";
-         }
+    /* parent */
+    $parent = $class->getParentClass();
+    if ($parent) {
+        echo " extends ", $parent->getName();
+    }
 
-         echo '$', $p->getName(), " = ";
+    /* interface */
+    $interfaces = $class->getInterfaceNames();
+    if (count($interfaces)) {
+        echo " implements ", join(", ", $interfaces);
+    }
+    echo " {\n";
 
-         if (isset($values[$p->getName()])) {
-             echo '"', $values[$p->getName()], '"';
-         } else {
-             echo "NULL";
-         }
-         echo ";\n";
-     }
-     echo "\n";
+    $indent .= "\t";
+    /* constants */
+    $constants = $class->getConstants();
+    if (0 < count($constants)) {
+      echo $indent, "/* constants */\n";
 
-     /* methods */
-     echo $indent, "/* methods */\n";
-     $methods = $class->getMethods();
-     foreach ($methods as $m) {
-         echo $indent;
-         echo implode(' ', Reflection::getModifierNames($m->getModifiers()));
-         echo " function ", $m->getName(), "(";
-         $parameters = $m->getParameters();
-         $number = count($parameters);
-         $index  = 0;
-         foreach ($parameters as $a) {
-             if (($type = $a->getClass())) {
-                 echo $type->getName(), " ";
-             } else if ($a->isArray()) {
-                 echo "array ";
-             }
+      foreach ($constants as $k => $v) {
+           echo $indent, "const ", $k , " = ", $v , ";\n";
+      }
+      echo "\n";
+    }
 
-             if ($a->isPassedByReference()) {
-                 echo "&";
-             }
+    /* properties */
+    $properties = $class->getProperties();
+    if (0 < count($properties)) {
+      echo $indent, "/* properties */\n";
+      $values     = $class->getDefaultProperties();
+      foreach ($properties as $p) {
+          echo $indent;
 
-             $name = $a->getName();
-             if ($name == "...") {
-                 echo '$_ = "..."';
-             } else {
-                 echo "$", $name;
-             }
+          if ($p->isStatic()) {
+              echo "static ";
+          }
 
-             if ($a->isOptional()) {
-                 if ($a->isDefaultValueAvailable()) {
-                     echo " = ", $a->getDefaultValue();
-                 } else {
-                     echo " = NULL";
-                 }
-             }
+          if ($p->isPublic()) {
+              echo "public ";
+          } else if ($p->isProtected()) {
+              echo "protected ";
+          } else {
+              echo "private ";
+          }
 
-             if (++$index < $number) {
-                 echo ", ";
-             }
-         }
+          echo '$', $p->getName(), " = ";
 
-         echo ") {\n";
-         echo $indent, "}\n";
-     }
-     echo "}\n\n";
+          if (isset($values[$p->getName()])) {
+              echo '"', $values[$p->getName()], '"';
+          } else {
+              echo "NULL";
+          }
+          echo ";\n";
+      }
+      echo "\n";
+    }
+
+    /* methods */
+    $methods = $class->getMethods();
+    if (0 < count($methods)) {
+      echo $indent, "/* methods */\n";
+
+      foreach ($methods as $m) {
+          echo $indent;
+          echo implode(' ', Reflection::getModifierNames($m->getModifiers()));
+          echo " function ", $m->getName(), "(";
+
+          if ($m->isAbstract()) {
+              // abstract methods are without a body "{ ... }"
+              echo ");\n";
+              continue;
+          }
+
+          $parameters = $m->getParameters();
+          $number = count($parameters);
+          $index  = 0;
+          foreach ($parameters as $a) {
+              if (($type = $a->getClass())) {
+                  echo $type->getName(), " ";
+              } else if ($a->isArray()) {
+                  echo "array ";
+              }
+
+              if ($a->isPassedByReference()) {
+                  echo "&";
+              }
+
+              $name = $a->getName();
+              if ($name == "...") {
+                  echo '$_ = "..."';
+              } else {
+                  echo "$", $name;
+              }
+
+              if ($a->isOptional()) {
+                  if ($a->isDefaultValueAvailable()) {
+                      echo " = ", $a->getDefaultValue();
+                  } else {
+                      echo " = NULL";
+                  }
+              }
+
+              if (++$index < $number) {
+                  echo ", ";
+              }
+          }
+
+          echo ") {\n";
+          echo $indent, "}\n";
+      }
+    }
+
+    $indent = substr($indent, 0, -1);
+    echo $indent, "}\n";
+
+    if ($useNamespace && false !== $backslash) {
+        echo "}\n\n";
+    }
 }


### PR DESCRIPTION
In case the `yaf.use_namespace` is enabled, the Yaf classes generator will create a valid skeleton with namespaces.

Underlined class names:
`$ php -d yaf.use_namespace=0 tools/yaf.php > /tmp/Yaf_underlined.php`

Class names with backslashes:
`$ php -d yaf.use_namespace=1 tools/yaf.php > /tmp/Yaf_namespaced.php`

P.S. Since the Yaf classes signature can be in 2 variants, the file `tools\yaf_classes.php` should be regenerated for both cases. Or as an option, to remove this file from repository at all.
