### PR TITLE
Fixes all tests to pass on most machines

### DIFF
--- a/tests/002.phpt
+++ b/tests/002.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Request_Simple
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $request  = new Yaf_Request_Simple("CLI", "index", "dummy", NULL, array());

--- a/tests/003.phpt
+++ b/tests/003.phpt
@@ -5,6 +5,7 @@ Check for Yaf_Loader
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php 
 ini_set("ap.lowcase_path", FALSE);

--- a/tests/004.phpt
+++ b/tests/004.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Registry
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $str = "Ageli Platform";

--- a/tests/005.phpt
+++ b/tests/005.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Response
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $response = new Yaf_Response_Http();

--- a/tests/006.phpt
+++ b/tests/006.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Route_Static
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $request_uri = "/prefix/controller/action/name/laruence/age/28";

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Config_Simple
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/008.phpt
+++ b/tests/008.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Router
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php
 

--- a/tests/009.phpt
+++ b/tests/009.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_View_Simple
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php
 $view = new Yaf_View_Simple(dirname(__FILE__));

--- a/tests/010.phpt
+++ b/tests/010.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Config_Ini
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $file = dirname(__FILE__) . "/simple.ini";

--- a/tests/011.phpt
+++ b/tests/011.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Route_Rewrite
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $request = new Yaf_Request_Http("/subdir/ap/1.2/name/value", "/subdir");

--- a/tests/012.phpt
+++ b/tests/012.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Route_Regex
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $request = new Yaf_Request_Http("/subdir/ap/1.2/name/value", "/subdir");

--- a/tests/013.phpt
+++ b/tests/013.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Router and Config Routes
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $file = dirname(__FILE__) . "/simple.ini";

--- a/tests/014.phpt
+++ b/tests/014.phpt
@@ -3,7 +3,8 @@ Check for Yaf_Application
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
-yaf.environ=product
+yaf.environ="product"
+yaf.use_namespace=0
 --FILE--
 <?php 
 define("APPLICATION_PATH", dirname(__FILE__));

--- a/tests/015.phpt
+++ b/tests/015.phpt
@@ -3,6 +3,8 @@ Check for Yaf_Exception
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 <?php if (version_compare(PHP_VERSION, "5.3.0", "lt")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $previous = new Yaf_Exception("Previous", 100);

--- a/tests/016.phpt
+++ b/tests/016.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Session
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $session = Yaf_Session::getInstance();

--- a/tests/017.phpt
+++ b/tests/017.phpt
@@ -2,6 +2,8 @@
 Bug (mem leak and crash in Yaf_Config_Ini)
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = new Yaf_Config_Ini;

--- a/tests/018.phpt
+++ b/tests/018.phpt
@@ -2,6 +2,8 @@
 Bug Yaf_Config_Ini crash due to inaccurate refcount
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $file = dirname(__FILE__) . "/simple.ini";

--- a/tests/019.phpt
+++ b/tests/019.phpt
@@ -2,6 +2,8 @@
 Yaf_Router::getCurrent with number key
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $request = new Yaf_Request_Http("/subdir/ap/1.2/name/value", "/subdir");

--- a/tests/020.phpt
+++ b/tests/020.phpt
@@ -3,6 +3,7 @@ Check for Yaf_Application
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/021.phpt
+++ b/tests/021.phpt
@@ -3,6 +3,7 @@ Check for Yaf_Application
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 define("APPLICATION_PATH", dirname(__FILE__));

--- a/tests/022.phpt
+++ b/tests/022.phpt
@@ -3,6 +3,7 @@ Check for Yaf_Application
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/023.phpt
+++ b/tests/023.phpt
@@ -5,6 +5,7 @@ Check for Yaf_Loader::set/get(library_path)
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php 
 $loader = Yaf_Loader::getInstance('/foo', '/bar');

--- a/tests/024.phpt
+++ b/tests/024.phpt
@@ -4,6 +4,7 @@ Check for Yaf_Loader::getInstace() paramters
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
 yaf.library="/php/global/dir"
+yaf.use_namespace=0
 --FILE--
 <?php 
 $loader = Yaf_Loader::getInstance('/foo', '/bar');

--- a/tests/025.phpt
+++ b/tests/025.phpt
@@ -4,6 +4,7 @@ Check for Yaf_Loader with namespace configuration
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
 yaf.library="/php/global/dir"
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/026.phpt
+++ b/tests/026.phpt
@@ -4,6 +4,7 @@ Check for Yaf_Response::setBody/prependBody/appendBody
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
 yaf.library="/php/global/dir"
+yaf.use_namespace=0
 --FILE--
 <?php 
 $response = new Yaf_Response_Http();

--- a/tests/027.phpt
+++ b/tests/027.phpt
@@ -5,7 +5,8 @@ Check for Yaf autoload controller
 --INI--
 yaf.use_spl_autoload=0
 yaf.library="/php/global/dir"
-yar.environ="product"
+yaf.environ="product"
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/028.phpt
+++ b/tests/028.phpt
@@ -4,6 +4,7 @@ Bug segfault while call exit in a view template
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
 yaf.library="/php/global/dir"
+yaf.use_namespace=0
 --FILE--
 <?php
 require "build.inc";

--- a/tests/029.phpt
+++ b/tests/029.phpt
@@ -4,6 +4,7 @@ Check for Yaf_View_Simple::get and clear
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
 yaf.library="/php/global/dir"
+yaf.use_namespace=0
 --FILE--
 <?php
 $view = new Yaf_View_Simple(dirname(__FILE__));

--- a/tests/030.phpt
+++ b/tests/030.phpt
@@ -4,6 +4,7 @@ Check for Yaf_Config_Ini::__construct with section
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
 yaf.library="/php/global/dir"
+yaf.use_namespace=0
 --FILE--
 <?php
 $file = dirname(__FILE__) . "/simple.ini";

--- a/tests/031.phpt
+++ b/tests/031.phpt
@@ -4,6 +4,7 @@ Check for application.dispatcher.defaultRoute
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
 yaf.library="/php/global/dir"
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/032.phpt
+++ b/tests/032.phpt
@@ -9,6 +9,7 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 ?>
 --INI--
 yaf.directory=/foo/bar
+yaf.use_namespace=0
 --FILE--
 <?php 
 putenv("FOO=bar");

--- a/tests/033.phpt
+++ b/tests/033.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_View_Simple with predefined template dir
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/034.phpt
+++ b/tests/034.phpt
@@ -7,6 +7,8 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip windows has a different absolute path');
 }
 ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $view = new Yaf_View_Simple("/tmp");

--- a/tests/035.phpt
+++ b/tests/035.phpt
@@ -9,6 +9,7 @@ if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
 ?>
 --INI--
 short_open_tag = 0
+yaf.use_namespace=0
 --FILE--
 <?php 
 $view = new Yaf_View_Simple(dirname(__FILE__));

--- a/tests/036.phpt
+++ b/tests/036.phpt
@@ -3,6 +3,7 @@ Check for Yaf_Route_Static with arbitrary urls
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
+yaf.use_namespace=0
 --FILE--
 <?php
 $url = array(

--- a/tests/037.phpt
+++ b/tests/037.phpt
@@ -11,6 +11,8 @@ if (version_compare(PHP_VERSION, "5.3", "lt")) {
 ?>
 --INI--
 yaf.lowcase_path=0
+yaf.use_spl_autoload=0
+yaf.use_namespace=0
 --FILE--
 <?php
 $dir = __DIR__;

--- a/tests/038.phpt
+++ b/tests/038.phpt
@@ -6,6 +6,7 @@ Check for Yaf_View_Simple error message outputing
 yaf.library="/php/global/dir"
 log_errors=0
 display_errors=1
+yaf.use_namespace=0
 --FILE--
 <?php
 require "build.inc";

--- a/tests/039.phpt
+++ b/tests/039.phpt
@@ -6,6 +6,7 @@ Check for Yaf_View_Simple recursive render error message outputing
 yaf.library="/php/global/dir"
 log_errors=0
 display_errors=1
+yaf.use_namespace=0
 --FILE--
 <?php
 require "build.inc";

--- a/tests/040.phpt
+++ b/tests/040.phpt
@@ -4,6 +4,7 @@ Fixed bug that segv in Yaf_View_Simple::render if the tpl is not a string
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
 yaf.library="/php/global/dir"
+yaf.use_namespace=0
 --FILE--
 <?php
 $view = new Yaf_View_Simple(dirname(__FILE__));

--- a/tests/041.phpt
+++ b/tests/041.phpt
@@ -2,6 +2,8 @@
 Check for controller return false preventing auto-renderring
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/042.phpt
+++ b/tests/042.phpt
@@ -2,6 +2,8 @@
 Check for throw exception in Yaf_Controller::init
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/043.phpt
+++ b/tests/043.phpt
@@ -9,6 +9,8 @@ yaf.cache_config=0
 yaf.name_suffix=1
 yaf.name_separator=""
 yaf.lowcase_path=1
+yaf.environ="product"
+yaf.use_namespace=0
 --FILE--
 <?php
 define("APPLICATION_PATH", dirname(__FILE__));

--- a/tests/044.phpt
+++ b/tests/044.phpt
@@ -4,6 +4,8 @@ Memleaks in Yaf_Dispatcher::getInstance()
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
 yaf.use_namespace=0
+yaf.environ="product"
+yaf.use_namespace=0
 --FILE--
 <?php
 define("APPLICATION_PATH", dirname(__FILE__));

--- a/tests/045.phpt
+++ b/tests/045.phpt
@@ -5,6 +5,8 @@ Check for segfault while use closure as error handler
 if (!extension_loaded("yaf")) print "skip";
 if (!version_compare(PHP_VERSION, "5.3", "ge")) print "skip only for 5.3+";
 ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/046.phpt
+++ b/tests/046.phpt
@@ -5,6 +5,7 @@ Check for Yaf_Loader with single class
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/047.phpt
+++ b/tests/047.phpt
@@ -5,6 +5,7 @@ Check for Yaf_Loader with spl_autoload
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php 
 $config = array(

--- a/tests/048.phpt
+++ b/tests/048.phpt
@@ -5,6 +5,7 @@ Check for Sample application
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 
 --FILE--
 <?php

--- a/tests/049.phpt
+++ b/tests/049.phpt
@@ -5,6 +5,7 @@ Check for Sample application with exception
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 
 --FILE--
 <?php 

--- a/tests/050.phpt
+++ b/tests/050.phpt
@@ -5,6 +5,7 @@ Check for Sample application with return response
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 
 --FILE--
 <?php 

--- a/tests/051.phpt
+++ b/tests/051.phpt
@@ -5,6 +5,7 @@ Fixed bug that segfault while a abnormal object set to Yaf_Route*::route
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php
 error_reporting(E_ALL & ~E_WARNING);

--- a/tests/052.phpt
+++ b/tests/052.phpt
@@ -4,6 +4,7 @@ Check for Yaf_Request APis
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
 yaf.use_spl_autoload=0
+yaf.use_namespace=0
 --FILE--
 <?php
 $request = new Yaf_Request_Http(new stdClass(), "xxxx", false);

--- a/tests/053.phpt
+++ b/tests/053.phpt
@@ -5,6 +5,7 @@ Check for Custom view engine
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php 
 require "build.inc";

--- a/tests/054.phpt
+++ b/tests/054.phpt
@@ -5,6 +5,7 @@ check for Various segfault
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php
 try {

--- a/tests/055.phpt
+++ b/tests/055.phpt
@@ -5,6 +5,8 @@ check for Yaf_Dispatcher::autoRender
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.environ="product"
+yaf.use_namespace=0
 --FILE--
 <?php
 define("APPLICATION_PATH", dirname(__FILE__));

--- a/tests/056.phpt
+++ b/tests/056.phpt
@@ -5,6 +5,8 @@ check for Yaf_Dispatcher::throwException
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.environ="product"
+yaf.use_namespace=0
 --FILE--
 <?php
 define("APPLICATION_PATH", dirname(__FILE__));

--- a/tests/057.phpt
+++ b/tests/057.phpt
@@ -5,6 +5,8 @@ check for Yaf_Dispatcher::catchException
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.environ="product"
+yaf.use_namespace=0
 --FILE--
 <?php
 define("APPLICATION_PATH", dirname(__FILE__));

--- a/tests/058.phpt
+++ b/tests/058.phpt
@@ -5,6 +5,8 @@ check for Yaf_Dispatcher::flushInstantly
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.environ="product"
+yaf.use_namespace=0
 --FILE--
 <?php
 define("APPLICATION_PATH", dirname(__FILE__));

--- a/tests/059.phpt
+++ b/tests/059.phpt
@@ -5,6 +5,7 @@ Check nesting view render
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php 
 require "build.inc";

--- a/tests/060.phpt
+++ b/tests/060.phpt
@@ -5,6 +5,7 @@ Check for working with other autoloaders
 --INI--
 yaf.use_spl_autoload=1
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php 
 require "build.inc";

--- a/tests/061.phpt
+++ b/tests/061.phpt
@@ -5,6 +5,7 @@ Bug empty template file interrupts forward chain
 --INI--
 yaf.use_spl_autoload=1
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php 
 require "build.inc";

--- a/tests/062.phpt
+++ b/tests/062.phpt
@@ -4,6 +4,7 @@ Check for Yaf_View_Simple and application's template directory
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
 yaf.library="/php/global/dir"
+yaf.use_namespace=0
 --FILE--
 <?php
 $view = new Yaf_View_Simple(dirname(__FILE__));

--- a/tests/063.phpt
+++ b/tests/063.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Route_Rewrite with dynamic mvc
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $request = new Yaf_Request_Http("/subdir/ctl/act/name/value");

--- a/tests/064.phpt
+++ b/tests/064.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Route_Regex with dynamic mvc
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $request = new Yaf_Request_Http("/subdir/ctl/act/name/value");

--- a/tests/065.phpt
+++ b/tests/065.phpt
@@ -2,6 +2,8 @@
 Yaf_Route_Regex map is optional
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 

--- a/tests/066.phpt
+++ b/tests/066.phpt
@@ -2,6 +2,8 @@
 Check for Yaf_Route_Regex with abnormal map
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php 
 $request = new Yaf_Request_Http("/subdir/ap/1.2/xxx/name/value", "/subdir");

--- a/tests/067.phpt
+++ b/tests/067.phpt
@@ -5,6 +5,7 @@ Check actions map with defined action class
 --INI--
 yaf.use_spl_autoload=0
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php 
 require "build.inc";

--- a/tests/bug61493.phpt
+++ b/tests/bug61493.phpt
@@ -4,6 +4,8 @@ Bug #61493 (Can't remove item when using unset() with a Yaf_Config_Simple instan
 littlemiaor at gmail dot com
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php
 

--- a/tests/bug62702.phpt
+++ b/tests/bug62702.phpt
@@ -2,6 +2,8 @@
 FR #62702 (Make baseuri case-insensitive)
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
 --FILE--
 <?php
 

--- a/tests/bug63381.phpt
+++ b/tests/bug63381.phpt
@@ -5,6 +5,7 @@ Bug #63381 ($_SERVER['SCRIPT_NAME'] changed by yaf)
 --INI--
 yaf.use_spl_autoload=1
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php 
 require "build.inc";

--- a/tests/bug63438.phpt
+++ b/tests/bug63438.phpt
@@ -5,6 +5,7 @@ Bug #63438 (Strange behavior with nested rendering)
 --INI--
 yaf.use_spl_autoload=1
 yaf.lowcase_path=0
+yaf.use_namespace=0
 --FILE--
 <?php
 

--- a/tests/bug63900.phpt
+++ b/tests/bug63900.phpt
@@ -7,6 +7,7 @@ yaf.use_spl_autoload=1
 yaf.lowcase_path=0
 yaf.throw_exception=0
 yaf.catch_exception=1
+yaf.use_namespace=0
 --FILE--
 <?php 
 require "build.inc";


### PR DESCRIPTION
Everyone who runs the "make test" may have different default Yaf`s INI
settings.
- in case the yaf.use_namespace=1 almost all tests fails
- in case the yaf.environ=dev around 5 tests fails
- in case the yaf.use_spl_autoload=1 one test fails

This fix specifies necessary INI values to pass all the tests.
