### PR TITLE
fix bug

### DIFF
--- a/routes/yaf_route_rewrite.c
+++ b/routes/yaf_route_rewrite.c
@@ -112,6 +112,7 @@ static zval * yaf_route_rewrite_match(yaf_route_t *router, char *uri, int len TS
 	}
 
 	efree(pmatch);
+	smart_str_appendc(&pattern, '$');
 	smart_str_appendc(&pattern, YAF_ROUTE_REGEX_DILIMITER);
 	smart_str_appendc(&pattern, 'i');
 	smart_str_0(&pattern);


### PR DESCRIPTION
当我要匹配一个片断 如exam 可是当我输入 exam1也被匹配上了 调试发现是因为没有结束符($)