### PR TITLE
Strange behavior.

### DIFF
--- a/yaf_exception.c
+++ b/yaf_exception.c
@@ -125,11 +125,8 @@ PHP_METHOD(yaf_exception, __construct) {
 		zend_update_property_long(Z_OBJCE_P(object), object, "code", sizeof("code")-1, code TSRMLS_CC);
 	}
 
-	if (previous) {
-		zend_update_property(Z_OBJCE_P(object), object, ZEND_STRL("previous"), previous TSRMLS_CC);
-	}
 	
-	efree(object);
+	zend_update_property(Z_OBJCE_P(object), object, ZEND_STRL("previous"), previous TSRMLS_CC);
 }
 /* }}} */
 

--- a/yaf_exception.c
+++ b/yaf_exception.c
@@ -128,6 +128,8 @@ PHP_METHOD(yaf_exception, __construct) {
 	if (previous) {
 		zend_update_property(Z_OBJCE_P(object), object, ZEND_STRL("previous"), previous TSRMLS_CC);
 	}
+	
+	e_free(object);
 }
 /* }}} */
 

--- a/yaf_exception.c
+++ b/yaf_exception.c
@@ -125,8 +125,9 @@ PHP_METHOD(yaf_exception, __construct) {
 		zend_update_property_long(Z_OBJCE_P(object), object, "code", sizeof("code")-1, code TSRMLS_CC);
 	}
 
-	
-	zend_update_property(Z_OBJCE_P(object), object, ZEND_STRL("previous"), previous TSRMLS_CC);
+        #if (PHP_VERSION_ID >= 50300)
+               zend_update_property(Z_OBJCE_P(object), object, ZEND_STRL("previous"), previous TSRMLS_CC); 
+        #endif
 }
 /* }}} */
 

--- a/yaf_exception.c
+++ b/yaf_exception.c
@@ -129,7 +129,7 @@ PHP_METHOD(yaf_exception, __construct) {
 		zend_update_property(Z_OBJCE_P(object), object, ZEND_STRL("previous"), previous TSRMLS_CC);
 	}
 	
-	e_free(object);
+	efree(object);
 }
 /* }}} */
 


### PR DESCRIPTION
I have been using the latest version of Yaf on xampp and i kept running into issues on the errorController at first i assumed it may of been a memory leak but then i think i pinpointed the issue:

object(Yaf_Exception_LoadFailed_Action) (8) {
  ["string":"Exception":private]=>
  string(0) ""
  ["file":protected]=>
  string(29) "C:\xampp\htdocs\dev\index.php"
  ["line":protected]=>
  int(13)
  ["trace":"Exception":private]=>
  array(1) {
    [0]=>
    array(6) {
      ["file"]=>
      string(29) "C:\xampp\htdocs\dev\index.php"
      ["line"]=>
      int(13)
      ["function"]=>
      string(3) "run"
      ["class"]=>
      string(15) "Yaf_Application"
      ["type"]=>
      string(2) "->"
      ["args"]=>
      array(0) {
      }
    }
  }
  ["message":protected]=>
  string(49) "There is no method indexAction in IndexController"
  ["code":protected]=>
  int(517)
  ["previous":protected]=>
  NULL
  ["previous":"Exception":private]=>
  &UNKNOWN:0
}

I believe the issue is &UNKNOWN:0, i checked a normal exception and when there is no previous the value is null so i made the change below and tested it and shows null as expected.