### PR TITLE
Fixed error due to undefined constant in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ application.ini is the application config file
 ```ini
 [product]
 ;CONSTANTS is supported
-application.directory = APP_PATH "/application/" 
+application.directory = APPLICATION_PATH "/application/" 
 ```
 alternatively, you can use a PHP array instead: 
 ```php


### PR DESCRIPTION
In your example, public/index has a constant defined as "APPLICATION_PATH" which point to the application folder. But in the conf/application.ini you [were] using APP_PATH which should be APPLICATION_PATH, otherwise your example won't work, unless the user creates another constant named APP_PATH in public/index.php
