### PR TITLE
优化yaf_simple_view 变量提取代码

### DIFF
--- a/views/yaf_view_simple.c
+++ b/views/yaf_view_simple.c
@@ -183,8 +183,8 @@ static int yaf_view_simple_extract(zval *tpl_vars, zval *vars TSRMLS_DC) {
 	}
 #endif
 
-	yaf_view_simple_extract_array(tpl_vars, 1 TSRMLS_DC);
-	yaf_view_simple_extract_array(vars, 0 TSRMLS_DC);
+	(void)yaf_view_simple_extract_array(tpl_vars, 1 TSRMLS_CC);
+	(void)yaf_view_simple_extract_array(vars, 0 TSRMLS_CC);
 
 	return 1;
 }

--- a/views/yaf_view_simple.c
+++ b/views/yaf_view_simple.c
@@ -168,6 +168,8 @@ static int yaf_view_simple_extract_array(zval *vars, int is_set_ref TSRMLS_DC) {
 			}
 		}
 	}
+
+	return 0;
 }
 
 /** {{{ static int yaf_view_simple_extract(zval *tpl_vars, zval *vars TSRMLS_DC)

--- a/views/yaf_view_simple.c
+++ b/views/yaf_view_simple.c
@@ -183,8 +183,8 @@ static int yaf_view_simple_extract(zval *tpl_vars, zval *vars TSRMLS_DC) {
 	}
 #endif
 
-	yaf_view_simple_extract_array(tpl_vars, 1);
-	yaf_view_simple_extract_array(vars, 0);
+	yaf_view_simple_extract_array(tpl_vars, 1 TSRMLS_DC);
+	yaf_view_simple_extract_array(vars, 0 TSRMLS_DC);
 
 	return 1;
 }


### PR DESCRIPTION
提取yaf_view_simple_extract函数公共代码，封装成yaf_view_simple_extract_array函数，提高代码的复用性。