### PR TITLE
add exception filter in EXCEPTION_HANDLER prevent yaf 'eat' Error

### DIFF
--- a/tests/080.phpt
+++ b/tests/080.phpt
@@ -1,0 +1,50 @@
+--TEST--
+PHP7 didn't display Error.
+--SKIPIF--
+<?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+
+--FILE--
+<?php 
+require "build.inc";
+startup();
+
+$config = array(
+	"application" => array(
+		"directory" => APPLICATION_PATH,
+	),
+);
+
+file_put_contents(APPLICATION_PATH . "/Bootstrap.php", <<<PHP
+<?php
+   class Bootstrap extends Yaf_Bootstrap_Abstract {
+   }
+PHP
+);
+
+file_put_contents(APPLICATION_PATH . "/controllers/Index.php", <<<PHP
+<?php
+class IndexController extends Yaf_Controller_Abstract {
+
+    public function indexAction() {
+        geoge();//funciton undefined!    
+    }    
+}
+PHP
+);
+
+$app = new Yaf_Application($config);
+$app->bootstrap()->run();
+?>
+--CLEAN--
+<?php
+require "build.inc"; 
+shutdown();
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Call to undefined function geoge() in %s:5
+Stack trace:
+#0 [internal function]: IndexController->indexAction()
+#1 %s080.php(30): Yaf_Application->run()
+#2 {main}
+  thrown in %s on line %d

--- a/yaf_dispatcher.c
+++ b/yaf_dispatcher.c
@@ -21,6 +21,7 @@
 #include "php.h"
 #include "main/SAPI.h" /* for sapi_module */
 #include "Zend/zend_interfaces.h" /* for zend_call_method_with_* */
+#include "Zend/zend_exceptions.h" /* for zend_exception_get_default */
 
 #include "php_yaf.h"
 #include "yaf_namespace.h"

--- a/yaf_exception.h
+++ b/yaf_exception.h
@@ -40,7 +40,8 @@
 
 #define YAF_EXCEPTION_HANDLE(dispatcher, request, response) \
 	if (EG(exception)) { \
-		if (YAF_G(catch_exception)) { \
+		if (YAF_G(catch_exception) \
+				 && instanceof_function(EG(exception)->ce, zend_exception_get_default())) { \
 			yaf_dispatcher_exception_handler(dispatcher, request, response); \
 		} \
 		zval_ptr_dtor(response); \
@@ -49,7 +50,8 @@
 
 #define YAF_EXCEPTION_HANDLE_NORET(dispatcher, request, response) \
 	if (EG(exception)) { \
-		if (YAF_G(catch_exception)) { \
+		if (YAF_G(catch_exception) \
+	   			&& instanceof_function(EG(exception)->ce, zend_exception_get_default())) { \
 			yaf_dispatcher_exception_handler(dispatcher, request, response); \
 		} \
 	}


### PR DESCRIPTION
```
class IndexController extends Yaf_Controller_Abstract
{
    public function indexAction() {
        george();//This function was undefined
        echo "test";
    }   
}
class ErrorController extends Yaf_Controller_Abstract {
    public function errorAction() {
        var_dump($this->getRequest());//That function underfined error can't print here
        var_dump($this->getRequest()->getException());//But not here
    }   
}
```