### PR TITLE
fix memory leak when alter body more then once

### DIFF
--- a/tests/081.phpt
+++ b/tests/081.phpt
@@ -1,0 +1,20 @@
+--TEST--
+PHP7 Yaf_Response leak memory
+--SKIPIF--
+<?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
+--FILE--
+<?php 
+$response = new Yaf_Response_Cli();
+
+$string = "Jason is a good boy";
+
+
+$response->setBody($string);
+$response->setBody($string);
+
+var_dump($response->getBody());
+?>
+--EXPECTF--
+string(19) "Jason is a good boy"

--- a/yaf_response.c
+++ b/yaf_response.c
@@ -163,6 +163,7 @@ int yaf_response_alter_body(yaf_response_t *response, zend_string *name, char *b
 				break;
 			case YAF_RESPONSE_REPLACE:
 			default:
+				zend_string_release(Z_STR_P(pzval));
 				ZVAL_STRINGL(pzval, body, body_len);
 				break;
 		}


### PR DESCRIPTION
> cat memleak.php 

```
<?php
$response = new Yaf_Response_Cli();


$string = "Jason is a good boy";
$string2 = "George is a good boy too";

$response->setBody($string);
$response->setBody($string2);

var_dump($response->getBody());
```

> php7 memleak.php 

```
string(24) "George is a good boy too"
[Mon Aug 17 11:41:43 2015]  Script:  '/usr/home/*****/testException/memleak.php'
/usr/local/php7/include/php/Zend/zend_string.h(121) :  Freeing 0x7FB2A7A01EB0 (48 bytes), script=/usr/home/*****/testException/memleak.php
=== Total 1 memory leaks detected ===
```