### PR TITLE
add yaf.use_namespace=0, In case of user config cause test fail

### DIFF
--- a/tests/080.phpt
+++ b/tests/080.phpt
@@ -3,7 +3,7 @@ PHP7 didn't display Error.
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
-
+yaf.use_namespace=0
 --FILE--
 <?php 
 require "build.inc";


### PR DESCRIPTION
Sorry, This test should force use_namespace=0, or it will fail when use's INI set it as  1;