### PR TITLE
FIX: php-fpm worker core dump BUG

### DIFF
--- a/yaf_request.c
+++ b/yaf_request.c
@@ -141,7 +141,7 @@ int yaf_request_set_base_uri(yaf_request_t *request, zend_string *base_uri, zend
 					}
 					zend_string_release(orig);
 				}
-				zval_ptr_dtor(orig_name);
+				if(NULL != orig_name) zval_ptr_dtor(orig_name);
 				zend_string_release(file_name);
 			}
 		} while (0);


### PR DESCRIPTION
前两天我从pecl下载了yaf-3.0.1（原先一直在使用yaf-3.0.0没有出现问题），突然就出现了nginx502。跟踪发现zval_ptr_dtor操作了一个空指针，现在增加了判断是否为空。不知对否，还请指教。