### PR TITLE
Check exception before use a newly created controller

### DIFF
--- a/yaf_dispatcher.c
+++ b/yaf_dispatcher.c
@@ -596,11 +596,11 @@ int yaf_dispatcher_handle(yaf_dispatcher_t *dispatcher, yaf_request_t *request, 
 			   }
 			   } while(0);
 			   */
-			yaf_controller_construct(ce, icontroller, request, response, view, NULL TSRMLS_CC);
 			if (EG(exception)) {
 				zval_ptr_dtor(&icontroller);
 				return 0;
 			}
+			yaf_controller_construct(ce, icontroller, request, response, view, NULL TSRMLS_CC);
 		
 			/* view template directory for application, please notice that view engine's directory has high priority */
 			if (is_def_module) {


### PR DESCRIPTION
Check exception before use a newly created controller as it might not be
successfully constructed. 

Here is a snippet of code that trigger this bug and cause a NULL pointer dereference

` use Yaf\Controller_Abstract;
  class TestController extends Controller_Abstract
  {
      public static $doomToFail = INVALID_CONSTANT_NAME;
  }
`