### PR TITLE
Check exception before use a newly created controller

### DIFF
--- a/yaf_dispatcher.c
+++ b/yaf_dispatcher.c
@@ -595,12 +595,12 @@ int yaf_dispatcher_handle(yaf_dispatcher_t *dispatcher, yaf_request_t *request, 
 				   }
 			   } while(0);
 		   */
-			yaf_controller_construct(ce, icontroller, request, response, view, NULL TSRMLS_CC);
-
 			if (EG(exception)) {
 				zval_ptr_dtor(&icontroller);
 				return 0;
 			}
+
+			yaf_controller_construct(ce, icontroller, request, response, view, NULL TSRMLS_CC);
 
 			if (!yaf_request_is_dispatched(request TSRMLS_CC)) {
 				/* forward is called in init method */
@@ -682,6 +682,11 @@ int yaf_dispatcher_handle(yaf_dispatcher_t *dispatcher, yaf_request_t *request, 
 
 				MAKE_STD_ZVAL(iaction);
 				object_init_ex(iaction, ce);
+				if (EG(exception)) {
+					zval_ptr_dtor(&iaction);
+					return 0;
+				}
+
 
 				yaf_controller_construct(ce, iaction, request, response, view, NULL TSRMLS_CC);
 				executor = iaction;


### PR DESCRIPTION
Check exception before use a newly created controller as it might not be
successfully constructed. There might be more like this other places, haven't checked yet.

Here is a snippet of code that trigger this bug and cause a NULL pointer dereference. 

`use Yaf\Controller_Abstract;
class TestController extends Controller_Abstract {
    public static $doomToFail = INVALID_CONSTANT_NAME;
}`