### PR TITLE
Add Yaf_Registry::flush and Yaf_Dispatcher::destoryInstance

### DIFF
--- a/yaf_dispatcher.c
+++ b/yaf_dispatcher.c
@@ -1130,6 +1130,14 @@ PHP_METHOD(yaf_dispatcher, getInstance) {
 }
 /* }}} */
 
+/** {{{ proto public Yaf_Dispatcher::destoryInstance(void)
+*/
+PHP_METHOD(yaf_dispatcher, destoryInstance) {
+	zend_update_static_property_null(yaf_dispatcher_ce, ZEND_STRL(YAF_DISPATCHER_PROPERTY_NAME_INSTANCE) TSRMLS_CC);
+	RETURN_TRUE;
+}
+/* }}} */
+
 /** {{{ proto public Yaf_Dispatcher::getRouter(void)
 */
 PHP_METHOD(yaf_dispatcher, getRouter) {
@@ -1377,6 +1385,7 @@ zend_function_entry yaf_dispatcher_methods[] = {
 	PHP_ME(yaf_dispatcher, throwException,			yaf_dispatcher_throwex_arginfo, 	ZEND_ACC_PUBLIC)
 	PHP_ME(yaf_dispatcher, catchException,			yaf_dispatcher_catchex_arginfo, 	ZEND_ACC_PUBLIC)
 	PHP_ME(yaf_dispatcher, registerPlugin,			yaf_dispatcher_regplugin_arginfo, 	ZEND_ACC_PUBLIC)
+	PHP_ME(yaf_dispatcher, destoryInstance,			yaf_dispatcher_void_arginfo, 		ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 	{NULL, NULL, NULL}
 };
 /* }}} */

--- a/yaf_registry.c
+++ b/yaf_registry.c
@@ -187,6 +187,23 @@ PHP_METHOD(yaf_registry, getInstance) {
 }
 /* }}} */
 
+/** {{{ proto public Yaf_Registry::flush(void)
+*/
+PHP_METHOD(yaf_registry, flush) {
+	yaf_registry_t 	*instance;
+	zval *regs;
+
+	instance = yaf_registry_instance(NULL TSRMLS_CC);
+
+	MAKE_STD_ZVAL(regs);
+	array_init(regs);
+	zend_update_property(yaf_registry_ce, instance, ZEND_STRL(YAF_REGISTRY_PROPERTY_NAME_ENTRYS), regs TSRMLS_CC);
+	zval_ptr_dtor(&regs);
+
+	RETURN_TRUE;
+}
+/* }}} */
+
 /** {{{ yaf_registry_methods
 */
 zend_function_entry yaf_registry_methods[] = {
@@ -196,6 +213,7 @@ zend_function_entry yaf_registry_methods[] = {
 	PHP_ME(yaf_registry, has, yaf_registry_has_arginfo, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME(yaf_registry, set, yaf_registry_set_arginfo, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME(yaf_registry, del, yaf_registry_del_arginfo, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(yaf_registry, flush, NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	{NULL, NULL, NULL}
 };
 /* }}} */


### PR DESCRIPTION
Yaf_Registry::flush
Yaf_Dispatcher::destoryInstance
从github.com/wenjun1055/swoole-yaf处看到的
在某些情况下，这两个方法应该是合理存在的