### PR TITLE
 创建Yaf_Application时根据参数更新environ属性[update environ from __construct]

### DIFF
--- a/yaf_application.c
+++ b/yaf_application.c
@@ -324,8 +324,13 @@ PHP_METHOD(yaf_application, __construct) {
 		ZVAL_STRING(&zsection, YAF_G(environ_name));
 		(void)yaf_config_instance(&zconfig, config, &zsection);
 		zval_ptr_dtor(&zsection);
+		zend_update_property_string(yaf_application_ce, self, 
+				ZEND_STRL(YAF_APPLICATION_PROPERTY_NAME_ENV), YAF_G(environ_name));		
 	} else {
 		(void)yaf_config_instance(&zconfig, config, section);
+		char *environ = estrdup(Z_STRVAL_P(section));
+		zend_update_property_string(yaf_application_ce, self, ZEND_STRL(YAF_APPLICATION_PROPERTY_NAME_ENV), environ);
+		efree(environ);
 	}
 
 	if  (UNEXPECTED(Z_TYPE(zconfig) != IS_OBJECT
@@ -382,7 +387,6 @@ PHP_METHOD(yaf_application, __construct) {
 	}
 
 	zend_update_property_bool(yaf_application_ce, self, ZEND_STRL(YAF_APPLICATION_PROPERTY_NAME_RUN), 0);
-	zend_update_property_string(yaf_application_ce, self, ZEND_STRL(YAF_APPLICATION_PROPERTY_NAME_ENV), YAF_G(environ_name));
 
 	if (Z_TYPE(YAF_G(modules)) == IS_ARRAY) {
 		zend_update_property(yaf_application_ce,


### PR DESCRIPTION
## 问题：

[Yaf_Application::environ()](http://php.net/manual/zh/yaf-application.environ.php) 总是读取php配置，而非使用的构造函数第二个参数$environ。

当设置的环境与系统不一致时，无法正确获取当前环境，(尤其是同主机运行多个不同环境的yaf应用时)
## 示例：

假设 系统php.ini配置中`yaf.environ = product`

``` php
<?php
$config = array(
    "application" => array(
        "directory" => dirname(__DIR__),
    ),
);
$app = new Yaf_Application($config,'dev');//使用dev环境
echo ini_get('yaf.environ'),' ',$app->environ();//显示系统配置的yaf环境和当前应用的yaf环境
```

输出结果是

```
product product
```

而非设置的$environ参数
## 修改内容：

> 创建Yaf_Application时，如果设置了合法的$environ 参数，优先采用此参数作为Yaf_Application的$_environ属性

既上面输出结果为

```
product dev
```
