### PR TITLE
setAllHeaders actually public access

### DIFF
--- a/responses/yaf_response_http.c
+++ b/responses/yaf_response_http.c
@@ -219,7 +219,7 @@ PHP_METHOD(yaf_response_http, setHeader) {
 }
 /* }}} */
 
-/** {{{ proto protected Yaf_Response_Http::setAllHeaders(void)
+/** {{{ proto public Yaf_Response_Http::setAllHeaders(void)
 */
 PHP_METHOD(yaf_response_http, setAllHeaders) {
   zval *headers;


### PR DESCRIPTION
see this line 
```c
  PHP_ME(yaf_response_http, setAllHeaders, yaf_response_http_set_all_headers_arginfo,   ZEND_ACC_PUBLIC)
```
on line 310

@laruence 