### PR TITLE
fix for PHP 7.2

### DIFF
--- a/configs/yaf_config_ini.c
+++ b/configs/yaf_config_ini.c
@@ -31,7 +31,7 @@
 
 zend_class_entry *yaf_config_ini_ce;
 
-#ifdef HAVE_SPL
+#if defined(HAVE_SPL) && PHP_VERSION_ID < 70200
 extern PHPAPI zend_class_entry *spl_ce_Countable;
 #endif
 
@@ -654,8 +654,10 @@ YAF_STARTUP_FUNCTION(config_ini) {
 	YAF_INIT_CLASS_ENTRY(ce, "Yaf_Config_Ini", "Yaf\\Config\\Ini", yaf_config_ini_methods);
 	yaf_config_ini_ce = zend_register_internal_class_ex(&ce, yaf_config_ce);
 
-#ifdef HAVE_SPL
+#if defined(HAVE_SPL) && PHP_VERSION_ID < 70200
 	zend_class_implements(yaf_config_ini_ce, 3, zend_ce_iterator, zend_ce_arrayaccess, spl_ce_Countable);
+#elif PHP_VERSION_ID >= 70200
+	zend_class_implements(yaf_config_ini_ce, 3, zend_ce_iterator, zend_ce_arrayaccess, zend_ce_countable);
 #else
 	zend_class_implements(yaf_config_ini_ce, 2, zend_ce_iterator, zend_ce_arrayaccess);
 #endif

--- a/configs/yaf_config_simple.c
+++ b/configs/yaf_config_simple.c
@@ -30,7 +30,7 @@
 
 zend_class_entry *yaf_config_simple_ce;
 
-#ifdef HAVE_SPL
+#if defined(HAVE_SPL) && PHP_VERSION_ID < 70200
 extern PHPAPI zend_class_entry *spl_ce_Countable;
 #endif
 
@@ -365,8 +365,10 @@ YAF_STARTUP_FUNCTION(config_simple) {
 	YAF_INIT_CLASS_ENTRY(ce, "Yaf_Config_Simple", "Yaf\\Config\\Simple", yaf_config_simple_methods);
 	yaf_config_simple_ce = zend_register_internal_class_ex(&ce, yaf_config_ce);
 
-#ifdef HAVE_SPL
+#if defined(HAVE_SPL) && PHP_VERSION_ID < 70200
 	zend_class_implements(yaf_config_simple_ce, 3, zend_ce_iterator, zend_ce_arrayaccess, spl_ce_Countable);
+#elif PHP_VERSION_ID >= 70200
+	zend_class_implements(yaf_config_simple_ce, 3, zend_ce_iterator, zend_ce_arrayaccess, zend_ce_countable);
 #else
 	zend_class_implements(yaf_config_simple_ce, 2, zend_ce_iterator, zend_ce_arrayaccess);
 #endif

--- a/requests/yaf_request_http.c
+++ b/requests/yaf_request_http.c
@@ -265,7 +265,7 @@ zend_function_entry yaf_request_http_methods[] = {
 	PHP_ME(yaf_request_http, get,			NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(yaf_request_http, isXmlHttpRequest, 	NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(yaf_request_http, __construct,		NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-	PHP_ME(yaf_request_http, __clone,		NULL, ZEND_ACC_PRIVATE | ZEND_ACC_CLONE)
+	PHP_ME(yaf_request_http, __clone,		NULL, ZEND_ACC_PRIVATE)
 	{NULL, NULL, NULL}
 };
 /* }}} */

--- a/requests/yaf_request_simple.c
+++ b/requests/yaf_request_simple.c
@@ -234,7 +234,7 @@ PHP_METHOD(yaf_request_simple, __clone) {
  */
 zend_function_entry yaf_request_simple_methods[] = {
 	PHP_ME(yaf_request_simple, __construct,	NULL, ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
-	PHP_ME(yaf_request_simple, __clone,		NULL, ZEND_ACC_PRIVATE|ZEND_ACC_CLONE)
+	PHP_ME(yaf_request_simple, __clone,		NULL, ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_request_simple, getQuery, 	NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(yaf_request_simple, getRequest, 	NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(yaf_request_simple, getPost, 		NULL, ZEND_ACC_PUBLIC)

--- a/yaf_application.c
+++ b/yaf_application.c
@@ -651,7 +651,7 @@ zend_function_entry yaf_application_methods[] = {
 	PHP_ME(yaf_application, getLastErrorMsg,     yaf_application_void_arginfo,         ZEND_ACC_PUBLIC)
 	PHP_ME(yaf_application, clearLastError,      yaf_application_void_arginfo,         ZEND_ACC_PUBLIC)
 	PHP_ME(yaf_application, __destruct,          NULL,                     ZEND_ACC_PUBLIC | ZEND_ACC_DTOR)
-	PHP_ME(yaf_application, __clone,             NULL,                     ZEND_ACC_PRIVATE | ZEND_ACC_CLONE)
+	PHP_ME(yaf_application, __clone,             NULL,                     ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_application, __sleep,             NULL,                     ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_application, __wakeup,            NULL,                     ZEND_ACC_PRIVATE)
 	{NULL, NULL, NULL}

--- a/yaf_dispatcher.c
+++ b/yaf_dispatcher.c
@@ -1314,7 +1314,7 @@ PHP_METHOD(yaf_dispatcher, __clone) {
 */
 zend_function_entry yaf_dispatcher_methods[] = {
 	PHP_ME(yaf_dispatcher, __construct, 			NULL, 					ZEND_ACC_PRIVATE | ZEND_ACC_CTOR)
-	PHP_ME(yaf_dispatcher, __clone,				NULL, 					ZEND_ACC_PRIVATE | ZEND_ACC_CLONE)
+	PHP_ME(yaf_dispatcher, __clone,				NULL, 					ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_dispatcher, __sleep,				NULL, 					ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_dispatcher, __wakeup,			NULL, 					ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_dispatcher, enableView,			yaf_dispatcher_void_arginfo,  		ZEND_ACC_PUBLIC)

--- a/yaf_loader.c
+++ b/yaf_loader.c
@@ -764,7 +764,7 @@ PHP_FUNCTION(yaf_override_spl_autoload) {
 */
 zend_function_entry yaf_loader_methods[] = {
 	PHP_ME(yaf_loader, __construct, yaf_loader_void_arginfo, ZEND_ACC_PRIVATE|ZEND_ACC_CTOR)
-	PHP_ME(yaf_loader, __clone, NULL, ZEND_ACC_PRIVATE|ZEND_ACC_CLONE)
+	PHP_ME(yaf_loader, __clone, NULL, ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_loader, __sleep, NULL, ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_loader, __wakeup, NULL, ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_loader, autoload, yaf_loader_autoloader_arginfo, ZEND_ACC_PUBLIC)

--- a/yaf_registry.c
+++ b/yaf_registry.c
@@ -186,7 +186,7 @@ PHP_METHOD(yaf_registry, getInstance) {
 */
 zend_function_entry yaf_registry_methods[] = {
 	PHP_ME(yaf_registry, __construct, 	NULL, ZEND_ACC_CTOR|ZEND_ACC_PRIVATE)
-	PHP_ME(yaf_registry, __clone, 		NULL, ZEND_ACC_CLONE|ZEND_ACC_PRIVATE)
+	PHP_ME(yaf_registry, __clone, 		NULL, ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_registry, get, yaf_registry_get_arginfo, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME(yaf_registry, has, yaf_registry_has_arginfo, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME(yaf_registry, set, yaf_registry_set_arginfo, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)

--- a/yaf_session.c
+++ b/yaf_session.c
@@ -19,7 +19,7 @@
 #endif
 
 #include "php.h"
-#include "Zend/zend_interfaces.h"  /* for zend_ce_iterator */
+#include "Zend/zend_interfaces.h"  /* for zend_ce_iterator, zend_ce_countable*/
 
 #include "php_yaf.h"
 #include "yaf_namespace.h"
@@ -28,7 +28,7 @@
 
 zend_class_entry *yaf_session_ce;
 
-#ifdef HAVE_SPL
+#if defined(HAVE_SPL) && PHP_VERSION_ID < 70200
 extern PHPAPI zend_class_entry *spl_ce_Countable;
 #endif
 
@@ -320,7 +320,7 @@ PHP_METHOD(yaf_session, valid) {
 */
 zend_function_entry yaf_session_methods[] = {
 	PHP_ME(yaf_session, __construct, NULL, ZEND_ACC_CTOR|ZEND_ACC_PRIVATE)
-	PHP_ME(yaf_session, __clone, NULL, ZEND_ACC_CLONE|ZEND_ACC_PRIVATE)
+	PHP_ME(yaf_session, __clone, NULL, ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_session, __sleep, NULL, ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_session, __wakeup, NULL, ZEND_ACC_PRIVATE)
 	PHP_ME(yaf_session, getInstance, yaf_session_void_arginfo, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
@@ -358,8 +358,10 @@ YAF_STARTUP_FUNCTION(session) {
 	yaf_session_ce = zend_register_internal_class_ex(&ce, NULL);
 	yaf_session_ce->ce_flags |= ZEND_ACC_FINAL;
 
-#ifdef HAVE_SPL
+#if defined(HAVE_SPL) && PHP_VERSION_ID < 70200
 	zend_class_implements(yaf_session_ce, 3, zend_ce_iterator, zend_ce_arrayaccess, spl_ce_Countable);
+#elif PHP_VERSION_ID >= 70200
+	zend_class_implements(yaf_session_ce, 3, zend_ce_iterator, zend_ce_arrayaccess, zend_ce_countable);
 #else
 	zend_class_implements(yaf_session_ce, 2, zend_ce_iterator, zend_ce_arrayaccess);
 #endif


### PR DESCRIPTION
* ZEND_ACC_CLONE have been removed (and was never used in previous version)
* spl_ce_Countable moved to zend_ce_countable

With this applied:
```
PHP_VERSION : 7.2.0alpha2

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   15
---------------------------------------------------------------------

Number of tests :   96                95
Tests skipped   :    1 (  1.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :   95 ( 99.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    2 seconds
=====================================================================

```