### PR TITLE
Remove unused Git attributes ident

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,4 +1,3 @@
-// $Id: config.w32 765 2010-10-21 13:04:03Z huixinchen $
 // vim:ft=javascript
 
 ARG_ENABLE("yaf", "enable yaf support", "no");

--- a/tools/yaf.php
+++ b/tools/yaf.php
@@ -4,7 +4,6 @@
  *
  * @author  Laruence
  * @date    2012-07-21 13:46
- * @version $Id$
  */
 
 $useNamespace = (bool) ini_get("yaf.use_namespace");


### PR DESCRIPTION
Hello,

The `$Id$` keywords were used in Subversion where they can be substituted with filename, last revision number change, last changed date, and last user who changed it.

In Git this functionality is different and can be done with Git attribute ident. These need to be defined manually for each file in the `.gitattributes` file and are afterwards replaced with 40-character hexadecimal blob object name which is based only on the particular file contents.

This patch simplifies handling of `$Id$` keywords by removing them since they are not used anymore.

Thank you...