### PR TITLE
增加yaf_view注册自定义方法

### DIFF
--- a/tests/009.phpt
+++ b/tests/009.phpt
@@ -16,7 +16,7 @@ var_dump($view->name);
 var_dump($view->noexists);
 print_r($view);
 var_dump($view->addMethod("test", function () {return "Yaf_View_Simple::test";}));
-
+var_dump($view->test());
 ?>
 --EXPECTF--
 Yaf_View_Simple Object
@@ -43,3 +43,4 @@ Yaf_View_Simple Object
     [_options:protected] => 
 )
 bool(true)
+string(21) "Yaf_View_Simple::test"

--- a/tests/009.phpt
+++ b/tests/009.phpt
@@ -15,6 +15,8 @@ var_dump(strlen($view->render(dirname(__FILE__) . "/001.phpt")));
 var_dump($view->name);
 var_dump($view->noexists);
 print_r($view);
+var_dump($view->addMethod("test", function () {return "Yaf_View_Simple::test";}));
+
 ?>
 --EXPECTF--
 Yaf_View_Simple Object
@@ -40,3 +42,4 @@ Yaf_View_Simple Object
     [_tpl_dir:protected] => %s
     [_options:protected] => 
 )
+bool(true)

--- a/yaf_view.h
+++ b/yaf_view.h
@@ -32,6 +32,7 @@ int yaf_view_simple_render(yaf_view_t *view, zval *tpl, zval * vars, zval *ret);
 int yaf_view_simple_display(yaf_view_t *view, zval *tpl, zval * vars, zval *ret);
 int yaf_view_simple_assign_multi(yaf_view_t *view, zval *value);
 void yaf_view_simple_clear_assign(yaf_view_t *view, zend_string *name);
+zend_bool yaf_view_add_method(yaf_view_t *view, zend_string *name, zval *closure);
 
 YAF_STARTUP_FUNCTION(view);
 


### PR DESCRIPTION
可以在yaf_view中调用addMethod，注册一个方法，在视图中可直接调用
$view = new Yaf_View_Simple(dirname(__FILE__));
$view->addMethod("test", function () {return "Yaf_View_Simple::test";});
$view->test();