### PR TITLE
Replace non-portable uint with unsigned

### DIFF
--- a/configs/yaf_config_ini.c
+++ b/configs/yaf_config_ini.c
@@ -237,7 +237,7 @@ static void yaf_config_ini_parser_cb(zval *key, zval *value, zval *index, int ca
 	if (callback_type == ZEND_INI_PARSER_SECTION) {
 		zval *parent;
 		char *seg, *skey, *skey_orig;
-		uint skey_len;
+		unsigned skey_len;
 
 		if (YAF_G(parsing_flag) == YAF_CONFIG_INI_PARSING_PROCESS) {
 			YAF_G(parsing_flag) = YAF_CONFIG_INI_PARSING_END;

--- a/php_yaf.h
+++ b/php_yaf.h
@@ -68,7 +68,7 @@ extern zend_module_entry yaf_module_entry;
 #define yaf_session_t		zval
 #define yaf_exception_t		zval
 
-#define YAF_ME(c, m, a, f) {m, PHP_MN(c), a, (uint) (sizeof(a)/sizeof(struct _zend_arg_info)-1), f},
+#define YAF_ME(c, m, a, f) {m, PHP_MN(c), a, (unsigned) (sizeof(a)/sizeof(struct _zend_arg_info)-1), f},
 
 extern PHPAPI void php_var_dump(zval **struc, int level);
 extern PHPAPI void php_debug_zval_dump(zval **struc, int level);
@@ -108,7 +108,7 @@ ZEND_BEGIN_MODULE_GLOBALS(yaf)
 	zval        *default_route;
 	zval        active_ini_file_section;
 	zval        *ini_wanted_section;
-	uint        parsing_flag;
+	unsigned    parsing_flag;
 	zend_bool	use_namespace;
 ZEND_END_MODULE_GLOBALS(yaf)
 

--- a/responses/yaf_response_http.c
+++ b/responses/yaf_response_http.c
@@ -96,7 +96,7 @@ int yaf_response_clear_header(yaf_response_t *response, zend_string *name) {
 
 /** {{{ int yaf_response_alter_header(yaf_response_t *response, zend_string *name, char *value, long value_len, int flag)
 */
-int yaf_response_alter_header(yaf_response_t *response, zend_string *name, char *value, long value_len, uint rep) {
+int yaf_response_alter_header(yaf_response_t *response, zend_string *name, char *value, long value_len, unsigned rep) {
 	zval *z_headers, *pzval;
 	zend_string *oheader;
 

--- a/responses/yaf_response_http.h
+++ b/responses/yaf_response_http.h
@@ -22,7 +22,7 @@
 
 extern zend_class_entry *yaf_response_http_ce;
 
-int yaf_response_alter_header(yaf_response_t *response, zend_string *name, char *value, long value_len, uint rep);
+int yaf_response_alter_header(yaf_response_t *response, zend_string *name, char *value, long value_len, unsigned rep);
 zval * yaf_response_get_header(yaf_response_t *response, zend_string *name);
 int yaf_response_clear_header(yaf_response_t *response, zend_string *name);
 

--- a/routes/yaf_route_map.c
+++ b/routes/yaf_route_map.c
@@ -64,7 +64,7 @@ int yaf_route_map_route(yaf_route_t *route, yaf_request_t *request) {
 	zval *ctl_prefer, *delimer, *zuri, *base_uri, params;
 	char *req_uri, *tmp, *rest, *ptrptr, *seg;
 	char *query_str = NULL;
-	uint seg_len = 0;
+	unsigned seg_len = 0;
 
 	smart_str route_result = {0};
 

--- a/views/yaf_view_simple.c
+++ b/views/yaf_view_simple.c
@@ -500,7 +500,7 @@ PHP_METHOD(yaf_view_simple, compose) {
 /** {{{ proto public Yaf_View_Simple::assign(mixed $value, mixed $value = null)
 */
 PHP_METHOD(yaf_view_simple, assign) {
-	uint argc = ZEND_NUM_ARGS();
+	unsigned argc = ZEND_NUM_ARGS();
 	if (argc == 1) {
 		zval *value;
 		if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &value) == FAILURE) {

--- a/yaf_application.c
+++ b/yaf_application.c
@@ -169,7 +169,7 @@ static int yaf_application_parse_option(zval *options) /* {{{ */ {
 			}
 			if ((psval = zend_hash_str_find(Z_ARRVAL_P(pzval),
 							ZEND_STRL("namespace"))) != NULL && Z_TYPE_P(psval) == IS_STRING) {
-				uint i, len;
+				unsigned i, len;
 				char *src = Z_STRVAL_P(psval);
 				if (Z_STRLEN_P(psval)) {
 				    char *target = emalloc(Z_STRLEN_P(psval) + 1);
@@ -517,7 +517,7 @@ PHP_METHOD(yaf_application, environ) {
 */
 PHP_METHOD(yaf_application, bootstrap) {
 	zend_string	*bootstrap_path;
-	uint  retval = 1;
+	unsigned  retval = 1;
 	zend_class_entry  *ce;
 	yaf_application_t *self = getThis();
 

--- a/yaf_dispatcher.c
+++ b/yaf_dispatcher.c
@@ -143,10 +143,10 @@ yaf_dispatcher_t *yaf_dispatcher_instance(yaf_dispatcher_t *this_ptr) /* {{{ */ 
 }
 /* }}} */
 
-static void yaf_dispatcher_get_call_parameters(zend_class_entry *request_ce, yaf_request_t *request, zend_function *fptr, zval **params, uint *count) /* {{{ */ {
+static void yaf_dispatcher_get_call_parameters(zend_class_entry *request_ce, yaf_request_t *request, zend_function *fptr, zval **params, unsigned *count) /* {{{ */ {
 	zval          *args, *arg;
 	zend_arg_info *arg_info;
-	uint           current;
+	unsigned       current;
 	HashTable 	  *params_ht;
 
 	args = zend_read_property(request_ce, request, ZEND_STRL(YAF_REQUEST_PROPERTY_NAME_PARAMS), 1, NULL);
@@ -417,7 +417,7 @@ zend_class_entry *yaf_dispatcher_get_action(zend_string *app_dir, yaf_controller
 /* {{{ This only effects internally */
 	   	if (YAF_G(st_compatible)) {
 		char *directory, *class, *class_lowercase, *p;
-		uint class_len;
+		unsigned class_len;
 		zend_class_entry *ce;
 		char *action_upper = estrndup(ZSTR_VAL(action), ZSTR_LEN(action));
 
@@ -588,7 +588,7 @@ int yaf_dispatcher_handle(yaf_dispatcher_t *dispatcher, yaf_request_t *request, 
 
 			/* @TODO: Magic __call supports? */
 			if ((fptr = zend_hash_find_ptr(&((ce)->function_table), func_name)) != NULL) {
-				uint count = 0;
+				unsigned count = 0;
 				zval *call_args = NULL;
 				executor = &icontroller;
 				if (fptr->common.num_args) {
@@ -625,7 +625,7 @@ int yaf_dispatcher_handle(yaf_dispatcher_t *dispatcher, yaf_request_t *request, 
 								YAF_ACTION_EXECUTOR_NAME, sizeof(YAF_ACTION_EXECUTOR_NAME) - 1))) {
 				zval *call_args;
 				yaf_action_t iaction;
-				uint count = 0;
+				unsigned count = 0;
 
 				zend_string_release(func_name);
 
@@ -835,7 +835,7 @@ yaf_response_t *yaf_dispatcher_dispatch(yaf_dispatcher_t *dispatcher, zval *resp
 	zval *return_response, *plugins, *view, rv;
 	yaf_response_t *response;
 	yaf_request_t *request;
-	uint nesting = YAF_G(forward_limit);
+	unsigned nesting = YAF_G(forward_limit);
 
 	response = yaf_response_instance(response_ptr, sapi_module.name);
 	request	= zend_read_property(yaf_dispatcher_ce,

--- a/yaf_exception.c
+++ b/yaf_exception.c
@@ -36,7 +36,7 @@ zend_class_entry *yaf_buildin_exceptions[YAF_MAX_BUILDIN_EXCEPTION];
 void yaf_trigger_error(int type, char *format, ...) {
 	va_list args;
 	char *message;
-	uint msg_len;
+	unsigned msg_len;
 
 	va_start(args, format);
 	msg_len = vspprintf(&message, 0, format, args);

--- a/yaf_request.c
+++ b/yaf_request.c
@@ -176,7 +176,7 @@ int yaf_request_set_base_uri(yaf_request_t *request, zend_string *base_uri, zend
 }
 /* }}} */
 
-zval *yaf_request_query_ex(uint type, zend_bool fetch_type, void *name, size_t len) /* {{{ */ {
+zval *yaf_request_query_ex(unsigned type, zend_bool fetch_type, void *name, size_t len) /* {{{ */ {
 	zval *carrier = NULL, *ret;
 
 	zend_bool jit_initialization = PG(auto_globals_jit);
@@ -299,7 +299,7 @@ zval *yaf_request_get_language(yaf_request_t *instance, zval *accept_language) /
 			return NULL;
 		} else {
 			char  	*ptrptr, *seg;
-			uint	prefer_len = 0;
+			unsigned	prefer_len = 0;
 			double	max_qvlaue = 0;
 			char 	*prefer = NULL;
 			char  	*langs = estrndup(Z_STRVAL_P(accept_langs), Z_STRLEN_P(accept_langs));
@@ -547,7 +547,7 @@ PHP_METHOD(yaf_request, setActionName) {
 /** {{{ proto public Yaf_Request_Abstract::setParam(mixed $value)
 */
 PHP_METHOD(yaf_request, setParam) {
-	uint argc;
+	unsigned argc;
 	yaf_request_t *self	= getThis();
 
 	argc = ZEND_NUM_ARGS();

--- a/yaf_request.h
+++ b/yaf_request.h
@@ -46,7 +46,7 @@ extern PHPAPI void php_session_start();
 
 yaf_request_t *yaf_request_instance(yaf_request_t *this_ptr, zend_string *info);
 int yaf_request_set_base_uri(yaf_request_t *request, zend_string *base_uri, zend_string *request_uri);
-zval *yaf_request_query_ex(uint type, zend_bool fetch_type, void *name, size_t len);
+zval *yaf_request_query_ex(unsigned type, zend_bool fetch_type, void *name, size_t len);
 
 zval *yaf_request_get_method(yaf_request_t *instance);
 zval *yaf_request_get_param(yaf_request_t *instance, zend_string *key);

--- a/yaf_response.c
+++ b/yaf_response.c
@@ -112,8 +112,8 @@ static int yaf_response_set_body(yaf_response_t *response, char *name, int name_
 /** {{{ int yaf_response_alter_body(yaf_response_t *response, zend_string *name, zend_string *body, int flag)
  */
 int yaf_response_alter_body(yaf_response_t *response, zend_string *name, zend_string *body, int flag) {
-	zval *zbody, *pzval;
-	uint  free_name = 0;
+	zval     *zbody, *pzval;
+	unsigned  free_name = 0;
 	zend_string *obody;
 
 	if (ZSTR_LEN(body) == 0) {

--- a/yaf_router.c
+++ b/yaf_router.c
@@ -151,7 +151,7 @@ int yaf_router_add_config(yaf_router_t *router, zval *configs) {
 void yaf_router_parse_parameters(char *uri, zval *params) {
 	char *key, *ptrptr, *tmp, *value;
 	zval val;
-	uint key_len;
+	unsigned key_len;
 
 	array_init(params);
 


### PR DESCRIPTION
As of PHP 7.4.0, the availability of `uint` is no longer guaranteed.
Therefore, we replace the type with the identical, but always available
`unsigned`.

This fixes the compilation on Windows, and maybe some other systems as
well.