### PR TITLE
Optimization Yaf_Response_* & Yaf_Request_*

### DIFF
--- a/requests/yaf_request_http.c
+++ b/requests/yaf_request_http.c
@@ -39,15 +39,8 @@ yaf_request_t *yaf_request_http_instance(yaf_request_t *this_ptr, zend_string *r
 	if (Z_ISUNDEF_P(this_ptr)) {
 		object_init_ex(this_ptr, yaf_request_http_ce);
 	}
-
-	if (SG(request_info).request_method) {
-		ZVAL_STRING(&method, (char *)SG(request_info).request_method);
-	} else if (strncasecmp(sapi_module.name, "cli", 3)) {
-		ZVAL_STRING(&method, "Unknow");
-	} else {
-		ZVAL_STRING(&method, "Cli");
-	}
-
+	
+	ZVAL_STRING(&method, yaf_request_get_request_method());
 	zend_update_property(yaf_request_http_ce, this_ptr, ZEND_STRL(YAF_REQUEST_PROPERTY_NAME_METHOD), &method);
 	zval_ptr_dtor(&method);
 

--- a/requests/yaf_request_simple.c
+++ b/requests/yaf_request_simple.c
@@ -33,15 +33,7 @@ yaf_request_t *yaf_request_simple_instance(yaf_request_t *this_ptr, zval *module
 	zval zv;
 
 	if (!method || Z_TYPE_P(method) != IS_STRING) {
-		if (!SG(request_info).request_method) {
-			if (!strncasecmp(sapi_module.name, "cli", 3)) {
-				ZVAL_STRING(&zv, "CLI");
-			} else {
-				ZVAL_STRING(&zv, "Unknow");
-			}
-		} else {
-			ZVAL_STRING(&zv, (char *)SG(request_info).request_method);
-		}
+		ZVAL_STRING(&zv, yaf_request_get_request_method());
 		method = &zv;
 	} else {
 		Z_TRY_ADDREF_P(method);

--- a/responses/yaf_response_http.c
+++ b/responses/yaf_response_http.c
@@ -136,8 +136,11 @@ int yaf_response_alter_header(yaf_response_t *response, zend_string *name, char 
 int yaf_response_set_redirect(yaf_response_t *response, char *url, int len) {
 	sapi_header_line ctr = {0};
 
-	ctr.line_len    = spprintf(&(ctr.line), 0, "%s %s", "Location:", url);
-	ctr.response_code   = 0;
+	if (strcmp("cli", sapi_module.name) == 0 || strcmp("phpdbg", sapi_module.name) == 0) {
+		return 0;
+	}
+	ctr.line_len = spprintf(&(ctr.line), 0, "%s %s", "Location:", url);
+	ctr.response_code = 0;
 	if (sapi_header_op(SAPI_HEADER_REPLACE, &ctr) == SUCCESS) {
 		efree(ctr.line);
 		return 1;

--- a/tests/006.phpt
+++ b/tests/006.phpt
@@ -27,7 +27,7 @@ Yaf_Request_Http Object
     [module] => 
     [controller] => controller
     [action] => action
-    [method] => Cli
+    [method] => CLI
     [params:protected] => Array
         (
             [name] => laruence

--- a/tests/014.phpt
+++ b/tests/014.phpt
@@ -110,7 +110,7 @@ Yaf_Application Object
                     [module] => 
                     [controller] => 
                     [action] => 
-                    [method] => Cli
+                    [method] => CLI
                     [params:protected] => Array
                         (
                         )

--- a/tests/086.phpt
+++ b/tests/086.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Check for Yaf_Response_HTTP::setRedirect in CLI
+--SKIPIF--
+<?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_namespace=0
+--FILE--
+<?php
+$response = new Yaf_Response_HTTP(); 
+var_dump($response->setRedirect('https://yourdomain.com'));
+?>
+--EXPECT--
+bool(false)

--- a/yaf_request.c
+++ b/yaf_request.c
@@ -19,6 +19,7 @@
 #endif
 
 #include "php.h"
+#include "main/SAPI.h"
 #include "standard/php_string.h" /* for php_basename */
 #include "Zend/zend_exceptions.h" /* for zend_exception_get_default */
 
@@ -395,6 +396,17 @@ int yaf_request_set_params_multi(yaf_request_t *request, zval *values) /* {{{ */
 zval * yaf_request_get_param(yaf_request_t *request, zend_string *key) /* {{{ */ {
 	zval *params = zend_read_property(yaf_request_ce, request, ZEND_STRL(YAF_REQUEST_PROPERTY_NAME_PARAMS), 1, NULL);
 	return zend_hash_find(Z_ARRVAL_P(params), key);
+}
+/* }}} */
+
+char *yaf_request_get_request_method(void) /* {{{ */ {
+	if (SG(request_info).request_method) {
+		return SG(request_info).request_method;
+	} else if (strncasecmp(sapi_module.name, "cli", 3) == 0) {
+		return "CLI";
+	} else {
+		return "UNKNOW";
+	}
 }
 /* }}} */
 

--- a/yaf_request.h
+++ b/yaf_request.h
@@ -58,6 +58,7 @@ void yaf_request_set_dispatched(yaf_request_t *request, int flag);
 void yaf_request_set_routed(yaf_request_t *request, int flag);
 int yaf_request_set_params_single(yaf_request_t *instance, zend_string *key, zval *value);
 int yaf_request_set_params_multi(yaf_request_t *instance, zval *values);
+char *yaf_request_get_request_method(void);
 
 #define yaf_request_query(type, name)  yaf_request_query_ex((type), 1, (name), 0)
 #define yaf_request_query_str(type, name, len)  yaf_request_query_ex((type), 0, (name), (len))


### PR DESCRIPTION
- Optimize redundant code
- Fix  Warning Yaf_Response_HTTP::setRedirect() in CLI
- Yaf_HTTP_*::getMethod() change the return value to uppercase, Keep the format consistent with the Request Method