### PR TITLE
支持控制器文件名称多字母驼峰命名风格

### DIFF
--- a/tests/issues408.phpt
+++ b/tests/issues408.phpt
@@ -1,0 +1,42 @@
+--TEST--
+ISSUE #408 ( 支持控制器文件名称多字母驼峰命名风格 )
+--SKIPIF--
+<?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_spl_autoload=0
+yaf.lowcase_path=0
+yaf.use_namespace=1
+--FILE--
+<?php
+require "build.inc";
+startup();
+
+$config = array(
+	"application" => array(
+		"directory" => APPLICATION_PATH,
+	),
+);
+
+file_put_contents(APPLICATION_PATH . "/controllers/GetUserInfo.php", <<<PHP
+<?php
+   class GetUserInfoController extends Yaf\Controller_Abstract {
+         public function indexAction() {
+            var_dump("GetUserInfoController");
+			return false;
+         }
+   }
+PHP
+);
+$app = new Yaf\Application($config);
+$module = "index";
+$controller = "get-user-info";
+$method = "index";
+$app->getDispatcher()->dispatch(new Yaf\Request\Simple("", $module, $controller,  $method,  []));
+?>
+--CLEAN--
+<?php
+require "build.inc"; 
+shutdown();
+?>
+--EXPECTF--
+string(21) "GetUserInfoController"

--- a/tests2/issues408.ppt
+++ b/tests2/issues408.ppt
@@ -1,0 +1,41 @@
+--TEST--
+ISSUE #408 (local variable is overrided by view renderring)
+--SKIPIF--
+<?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_spl_autoload=0
+yaf.lowcase_path=0
+yaf.use_namespace=1
+--FILE--
+<?php
+$config = array(
+	"application" => array(
+		"directory" => APPLICATION_PATH,
+	),
+);
+
+file_put_contents(APPLICATION_PATH . "/controllers/GetUserInfo.php", <<<PHP
+<?php
+   class GetUserInfoController extends Yaf_Controller_Abstract {
+         public function indexAction() {
+            echo "GetUserInfoController";
+			return false;
+         }
+   }
+PHP
+);
+$app = new Yaf_Application($config);
+$module = "index";
+$controller = "get-user-info";
+$method = "index";
+$app->getDispatcher()->dispatch(new Yaf\Request\Simple("", $module, $controller,  $method,  []));
+
+?>
+--CLEAN--
+<?php
+/* unlink foo2.phtml permission denied */
+require "build.inc"; 
+shutdown();
+?>
+--EXPECTF--
+bool(true)


### PR DESCRIPTION
支持控制器文件名称多字母驼峰命名风格
把文件名GetUserInfo.php 写成Getuserinfo.php，不是很友好。
文件名: GetUserInfo.php
 class GetUserInfoController extends Yaf\Controller_Abstract {
         public function indexAction() {
            var_dump("GetUserInfoController");
			return false;
         }
   }

可以使用url:  /get-user-info/index  访问
 