### PR TITLE
Fixed compiler warning

### DIFF
--- a/configs/yaf_config_ini.c
+++ b/configs/yaf_config_ini.c
@@ -339,7 +339,7 @@ static void yaf_config_ini_parser_cb(zval *key, zval *value, zval *index, int ca
 		yaf_config_ini_strip_section_name(&p, &l, 3);
 
 		array_init(&YAF_G(active_ini_file_section));
-		while ((colon = memrchr(p, ':', l))) {
+		while ((colon = zend_memrchr(p, ':', l))) {
 			const char *pp = colon + 1;
 			size_t pl = l - (colon + 1 - p);
 

--- a/responses/yaf_response_http.c
+++ b/responses/yaf_response_http.c
@@ -172,7 +172,7 @@ int yaf_response_http_send(yaf_response_t *response) {
         if (header_name) {
 			ctr.line_len = spprintf(&(ctr.line), 0, "%s: %s", ZSTR_VAL(header_name), Z_STRVAL_P(entry));
 		} else {
-			ctr.line_len = spprintf(&(ctr.line), 0, "%lu: %s", num_key, Z_STRVAL_P(entry));
+			ctr.line_len = spprintf(&(ctr.line), 0, "%llu: %s", num_key, Z_STRVAL_P(entry));
 		}
 
 		ctr.response_code = 0;

--- a/yaf.c
+++ b/yaf.c
@@ -193,7 +193,7 @@ PHP_RSHUTDOWN_FUNCTION(yaf)
 	}
 	if (YAF_G(local_namespaces)) {
 #if PHP_VERSION_ID >70300
-		if (zend_gc_delref(YAF_G(local_namespaces)) == 0)
+		if (zend_gc_delref((zend_refcounted_h*)YAF_G(local_namespaces)) == 0)
 #else
 		if (--(GC_REFCOUNT(YAF_G(local_namespaces))) == 0)
 #endif
@@ -208,7 +208,7 @@ PHP_RSHUTDOWN_FUNCTION(yaf)
 	}
 	if (YAF_G(modules)) {
 #if PHP_VERSION_ID >70300
-		if (zend_gc_delref(YAF_G(modules)) == 0)
+		if (zend_gc_delref((zend_refcounted_h*)YAF_G(modules)) == 0)
 #else
 		if (--(GC_REFCOUNT(YAF_G(modules))) == 0)
 #endif

--- a/yaf_router.c
+++ b/yaf_router.c
@@ -135,7 +135,7 @@ int yaf_router_add_config(yaf_router_t *router, zval *configs) {
 				zend_hash_update(Z_ARRVAL_P(routes), key, route);
 			} else {
 				if (!route) {
-					php_error_docref(NULL, E_WARNING, "Unable to initialize route at index '%ld'", idx);
+					php_error_docref(NULL, E_WARNING, "Unable to initialize route at index '%llu'", idx);
 					continue;
 				}
 				zend_hash_index_update(Z_ARRVAL_P(routes), idx, route);


### PR DESCRIPTION
OS Env:
```
brew config
HOMEBREW_VERSION: 2.2.10-54-g8fa2d15
ORIGIN: https://github.com/Homebrew/brew
HEAD: 8fa2d151dd6b02b27077363f901c30c1469b4660
Last commit: 33 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 56d51cf53160b54978f3e55376bc943601eba9f9
Core tap last commit: 27 hours ago
HOMEBREW_PREFIX: /usr/local
HOMEBREW_DEV_CMD_RUN: 1
CPU: dodeca-core 64-bit kabylake
Homebrew Ruby: 2.6.3 => /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby
Clang: 11.0 build 1100
Git: 2.25.1 => /usr/local/bin/git
Curl: 7.64.1 => /usr/bin/curl
Java: 1.8.0_221
macOS: 10.15.3-x86_64
CLT: 11.3.1.0.1.1576735732
Xcode: 11.3.1
```


```
/Users/xx/Downloads/yaf-3.1.0/yaf.c:196:22: warning: incompatible pointer types passing 'zend_array *' (aka 'struct _zend_array *') to parameter of type 'zend_refcounted_h *'
      (aka 'struct _zend_refcounted_h *') [-Wincompatible-pointer-types]
                if (zend_gc_delref(YAF_G(local_namespaces)) == 0)
                                   ^~~~~~~~~~~~~~~~~~~~~~~
./php_yaf.h:39:18: note: expanded from macro 'YAF_G'
#define YAF_G(v) (yaf_globals.v)
                 ^~~~~~~~~~~~~~~
/usr/local/Cellar/php/7.4.3/include/php/Zend/zend_types.h:1038:70: note: passing argument to parameter 'p' here
static zend_always_inline uint32_t zend_gc_delref(zend_refcounted_h *p) {
                                                                     ^
/Users/xx/Downloads/yaf-3.1.0/yaf.c:211:22: warning: incompatible pointer types passing 'zend_array *' (aka 'struct _zend_array *') to parameter of type 'zend_refcounted_h *'
      (aka 'struct _zend_refcounted_h *') [-Wincompatible-pointer-types]
                if (zend_gc_delref(YAF_G(modules)) == 0)
                                   ^~~~~~~~~~~~~~
./php_yaf.h:39:18: note: expanded from macro 'YAF_G'
#define YAF_G(v) (yaf_globals.v)
                 ^~~~~~~~~~~~~~~
/usr/local/Cellar/php/7.4.3/include/php/Zend/zend_types.h:1038:70: note: passing argument to parameter 'p' here
static zend_always_inline uint32_t zend_gc_delref(zend_refcounted_h *p) {
                                                                     ^
2 warnings generated.


/Users/xx/Downloads/yaf-yaf-3.1.0/configs/yaf_config_ini.c:342:19: warning: implicit declaration of function 'memrchr' is invalid in C99 [-Wimplicit-function-declaration]
                while ((colon = memrchr(p, ':', l))) {
                                ^
/Users/xx/Downloads/yaf-yaf-3.1.0/configs/yaf_config_ini.c:342:17: warning: incompatible integer to pointer conversion assigning to 'const char *' from 'int' [-Wint-conversion]
                while ((colon = memrchr(p, ':', l))) {
                              ^ ~~~~~~~~~~~~~~~~~~
2 warnings generated.


/Users/xx/Downloads/yaf-3.1.0/responses/yaf_response_http.c:175:55: warning: format specifies type 'unsigned long' but the argument has type 'zend_ulong' (aka 'unsigned long long') [-Wformat]
                        ctr.line_len = spprintf(&(ctr.line), 0, "%lu: %s", num_key, Z_STRVAL_P(entry));
                                                                 ~~~       ^~~~~~~
                                                                 %llu
1 warning generated.


/Users/xx/Downloads/yaf-3.1.0/yaf_router.c:138:85: warning: format specifies type 'long' but the argument has type 'zend_ulong' (aka 'unsigned long long') [-Wformat]
                                        php_error_docref(NULL, E_WARNING, "Unable to initialize route at index '%ld'", idx);
                                                                                                                ~~~    ^~~
                                                                                                                %llu
1 warning generated.




```
