### PR TITLE
fix symbol_table op

### DIFF
--- a/tests/pr468.phpt
+++ b/tests/pr468.phpt
@@ -1,0 +1,67 @@
+--TEST--
+PR #468 Check for sysboml table bug
+--SKIPIF--
+<?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_spl_autoload=0
+yaf.use_namespace=0
+
+--FILE--
+<?php
+require "build.inc";
+startup();
+
+$config = array(
+	"application" => array(
+		"directory" => APPLICATION_PATH,
+        "dispatcher" => array (
+           "catchException" => true,
+        ),
+        "library" => array(
+        ),
+	),
+);
+
+file_put_contents(APPLICATION_PATH . "/Bootstrap.php", <<<PHP
+<?php
+   class Bootstrap extends Yaf_Bootstrap_Abstract {
+        public function _initConfig(Yaf_Dispatcher \$dispatcher) {
+            Yaf_Registry::set("config", Yaf_Application::app()->getConfig());
+        }
+   }
+PHP
+);
+
+
+$value = NULL;
+
+file_put_contents(APPLICATION_PATH . "/controllers/Index.php", <<<PHP
+<?php
+   class IndexController extends Yaf_Controller_Abstract {
+         public function init() {}
+
+         public function indexAction() {
+            \$this->getView()->assign("ref", "ref-source");
+            \$this->getView()->display("index/index.phtml", ["ref" => "ref-changed"]);
+            return false;
+         }
+   }
+PHP
+);
+
+file_put_contents(APPLICATION_PATH . "/views/index/index.phtml", "<?php
+   var_dump(\$ref);
+?>");
+
+$app = new Yaf_Application($config);
+$app->bootstrap()->run();
+
+?>
+--CLEAN--
+<?php
+require "build.inc";
+shutdown();
+?>
+--EXPECTF--
+string(11) "ref-changed"
+

--- a/views/yaf_view_simple.c
+++ b/views/yaf_view_simple.c
@@ -99,17 +99,15 @@ static int yaf_view_simple_valid_var_name(char *var_name, int len) /* {{{ */
 static zend_array *yaf_view_build_symtable(zval *tpl_vars, zval *vars) /* {{{ */ {
 	zval *entry;
 	zend_string *var_name;
-	zend_array *symbol_table;
+	HashTable *symbol_table;
 #if PHP_VERSION_ID < 70100
 	zend_class_entry *scope = EG(scope);
 #else
 	zend_class_entry *scope = zend_get_executed_scope();
 #endif
 
-	symbol_table = emalloc(sizeof(zend_array));
-
+	ALLOC_HASHTABLE(symbol_table);
 	zend_hash_init(symbol_table, 8, NULL, ZVAL_PTR_DTOR, 0);
-	zend_hash_real_init(symbol_table, 0);
 
 	if (tpl_vars && Z_TYPE_P(tpl_vars) == IS_ARRAY) {
 	    ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(tpl_vars), var_name, entry) {
@@ -142,7 +140,7 @@ static zend_array *yaf_view_build_symtable(zval *tpl_vars, zval *vars) /* {{{ */
 			}
 
 			if (yaf_view_simple_valid_var_name(ZSTR_VAL(var_name), ZSTR_LEN(var_name))) {
-				if (EXPECTED(zend_hash_add_new(symbol_table, var_name, entry))) {
+				if (EXPECTED(zend_hash_update(symbol_table, var_name, entry))) {
 					Z_TRY_ADDREF_P(entry);
 				}
 			}


### PR DESCRIPTION
> must have PHP configured with --enable-debug

PHP-FPM Error log:
`child 27689 exited on signal 6 (SIGABRT - core dumped) after 10.906112 seconds from start`

LLDB BT:
```
(lldb) bt
* thread #1, stop reason = signal SIGSTOP
  * frame #0: 0x00007fff67de47fa libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007fff67ea1bc1 libsystem_pthread.dylib`pthread_kill + 432
    frame #2: 0x00007fff67d6ba1c libsystem_c.dylib`abort + 120
    frame #3: 0x00007fff67d6acd6 libsystem_c.dylib`__assert_rtn + 314
    frame #4: 0x000000010e04a3d7 php-fpm`_zend_hash_add_or_update_i(ht=0x0000000111506180, key=0x000000011204c040, pData=0x00000001114f28c0, flag=8) at zend_hash.c:734:4
    frame #5: 0x000000010e04a15a php-fpm`zend_hash_add_new(ht=0x0000000111506180, key=0x000000011204c040, pData=0x00000001114f28c0) at zend_hash.c:889:9
    frame #6: 0x000000011180a3ab yaf.so`yaf_view_build_symtable(tpl_vars=0x000000011150b268, vars=0x0000000111418300) at yaf_view_simple.c:145:9
    frame #7: 0x0000000111809e28 yaf.so`yaf_view_simple_render(view=0x00000001114182c0, tpl=0x00000001114182f0, vars=0x0000000111418300, ret=0x0000000111418290) at yaf_view_simple.c:309:17
    frame #8: 0x000000011180bfd5 yaf.so`zim_yaf_view_simple_render(execute_data=0x00000001114182a0, return_value=0x0000000111418290) at yaf_view_simple.c:586:7
    frame #9: 0x000000010e0e613f php-fpm`ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER(execute_data=0x0000000111418220) at zend_vm_execute.h:1730:4
    frame #10: 0x000000010e0a5c14 php-fpm`execute_ex(ex=0x0000000111418160) at zend_vm_execute.h:53611:7
    frame #11: 0x000000010e0122b1 php-fpm`zend_call_function(fci=0x00007ffee2347198, fci_cache=0x00007ffee2347118) at zend_execute_API.c:812:3
    frame #12: 0x000000010e065072 php-fpm`zend_call_method(object=0x0000000111403588, obj_ce=0x0000000111408d40, fn_proxy=0x0000000000000000, function_name="render", function_name_len=6, retval_ptr=0x00007ffee23472b0, param_count=1, arg1=0x00007ffee23472c0, arg2=0x0000000000000000) at zend_interfaces.c:103:12
    frame #13: 0x000000011180cf3d yaf.so`yaf_controller_render(instance=0x0000000111418120, action_name="index", len=5, var_array=0x0000000000000000) at yaf_controller.c:135:3
    frame #14: 0x000000011180f2cb yaf.so`zim_yaf_controller_render(execute_data=0x0000000111418100, return_value=0x00007ffee2347808) at yaf_controller.c:485:25
    frame #15: 0x000000010e01238a php-fpm`zend_call_function(fci=0x00007ffee23475f8, fci_cache=0x00007ffee2347578) at zend_execute_API.c:825:4
    frame #16: 0x000000010e065072 php-fpm`zend_call_method(object=0x00007ffee23477d0, obj_ce=0x0000000111411940, fn_proxy=0x0000000000000000, function_name="render", function_name_len=6, retval_ptr=0x00007ffee2347808, param_count=1, arg1=0x00007ffee23477f8, arg2=0x0000000000000000) at zend_interfaces.c:103:12
    frame #17: 0x00000001117f1fe8 yaf.so`yaf_dispatcher_handle(dispatcher=0x0000000111472038, request=0x0000000111403248, response=0x00007ffee2347ba0, view=0x0000000111403238) at yaf_dispatcher.c:627:7
    frame #18: 0x00000001117f370e yaf.so`yaf_dispatcher_dispatch(dispatcher=0x0000000111472038, response_ptr=0x00007ffee2347ba0) at yaf_dispatcher.c:821:8
    frame #19: 0x00000001117ee708 yaf.so`zim_yaf_application_run(execute_data=0x00000001114180b0, return_value=0x00007ffee2347ba0) at yaf_application.c:466:6
    frame #20: 0x000000010e0e5b54 php-fpm`ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_HANDLER(execute_data=0x0000000111418020) at zend_vm_execute.h:1618:4
    frame #21: 0x000000010e0a5c14 php-fpm`execute_ex(ex=0x0000000111418020) at zend_vm_execute.h:53611:7
    frame #22: 0x000000010e0a5e4b php-fpm`zend_execute(op_array=0x0000000111403000, return_value=0x0000000000000000) at zend_vm_execute.h:57913:2
    frame #23: 0x000000010e0316c2 php-fpm`zend_execute_scripts(type=8, retval=0x0000000000000000, file_count=3) at zend.c:1665:4
    frame #24: 0x000000010df7cce6 php-fpm`php_execute_script(primary_file=0x00007ffee2348740) at main.c:2617:14
    frame #25: 0x000000010e157a0a php-fpm`main(argc=6, argv=0x00007ffee2348a68) at fpm_main.c:1942:4
    frame #26: 0x00007fff67c9d7fd libdyld.dylib`start + 1
    frame #27: 0x00007fff67c9d7fd libdyld.dylib`start + 1
```