### PR TITLE
relax test, don't rely on sources path

### DIFF
--- a/tests/issue231.phpt
+++ b/tests/issue231.phpt
@@ -40,7 +40,7 @@ Yaf_Request_Http::__set_state(array(
    'controller' => NULL,
    'action' => NULL,
    'uri:protected' => '%stests',
-   'base_uri:protected' => '%syaf',
+   'base_uri:protected' => '%s',
    'dispatched:protected' => false,
    'routed:protected' => false,
    'language:protected' => '',


### PR DESCRIPTION
Really minor.

Context: during RPM build directory is not "yaf" (but something related to build type, e.g. "nts" or "zts")