### PR TITLE
Fix build

### DIFF
--- a/php_yaf.h
+++ b/php_yaf.h
@@ -154,7 +154,7 @@ int yaf_call_user_method_with_1_arguments(zend_object *obj, zend_function *fbc, 
 int yaf_call_user_method_with_2_arguments(zend_object *obj, zend_function *fbc, zval *arg1, zval *arg2, zval *ret);
 void yaf_replace_chr(char *name, uint32_t len, zend_uchar f, zend_uchar t);
 
-extern const char const *yaf_known_chars[];
+extern const char *yaf_known_chars[];
 extern zend_string **yaf_known_strings;
 #define YAF_KNOWN_STR(id)        (yaf_known_strings[id])
 #define YAF_KNOWN_CHARS(id)      (yaf_known_chars[id])

--- a/routes/yaf_route_map.c
+++ b/routes/yaf_route_map.c
@@ -131,14 +131,14 @@ static inline zend_string *yaf_route_map_build(const char *src, size_t len, zend
 		unsigned char *p, *q, *e;
 		zend_string *result = zend_string_alloc(end - str, 0);
 
-		zend_str_tolower_copy(ZSTR_VAL(result), str, end - str);
+		zend_str_tolower_copy(ZSTR_VAL(result), (char *) str, end - str);
 		p = q = (unsigned char*)ZSTR_VAL(result);
 		e = p + ZSTR_LEN(result);
 
 		if (ctl) {
 			*p++ = toupper(*q++);
 		} else {
-			*p++, *q++;
+			p++, q++;
 		}
 		while (q < e) {
 			if (*q == YAF_ROUTER_URL_DELIMIETER) {

--- a/views/yaf_view_simple.c
+++ b/views/yaf_view_simple.c
@@ -411,8 +411,10 @@ static int yaf_view_simple_eval(yaf_view_t *view, zend_string *tpl, zval * vars,
 		ZVAL_STR(&phtml, strpprintf(0, "?>%s", ZSTR_VAL(tpl)));
 #if PHP_VERSION_ID < 80000
 		op_array = zend_compile_string(&phtml, eval_desc);
-#else
+#elif PHP_VERSION_ID < 80200
         op_array = zend_compile_string(Z_STR(phtml), eval_desc);
+#else
+        op_array = zend_compile_string(Z_STR(phtml), eval_desc, ZEND_COMPILE_POSITION_AFTER_OPEN_TAG);
 #endif
 		zval_dtor(&phtml);
 		efree(eval_desc);

--- a/yaf.c
+++ b/yaf.c
@@ -50,7 +50,7 @@
 ZEND_DECLARE_MODULE_GLOBALS(yaf);
 
 zend_string **yaf_known_strings = NULL;
-const char const *yaf_known_chars[] = {
+const char *yaf_known_chars[] = {
 #define _YAF_CHARS(id, str) str,
 YAF_KNOWN_NAMES(_YAF_CHARS)
 #undef _YAF_CHARS
@@ -600,7 +600,7 @@ PHP_MSHUTDOWN_FUNCTION(yaf)
 
 	UNREGISTER_INI_ENTRIES();
 
-	for (idx; idx < sizeof(yaf_known_chars)/sizeof(char*) - 1; idx++) {
+	for (; idx < sizeof(yaf_known_chars)/sizeof(char*) - 1; idx++) {
 		free(yaf_known_strings[idx]);
 	}
 	free(yaf_known_strings);

--- a/yaf_dispatcher.c
+++ b/yaf_dispatcher.c
@@ -822,6 +822,7 @@ ZEND_HOT yaf_response_t *yaf_dispatcher_dispatch(yaf_dispatcher_object *dispatch
 		ZEND_ASSERT(nesting == 0);
 		yaf_trigger_error(YAF_ERR_DISPATCH_FAILED, "The maximum dispatching count %ld is reached", yaf_get_forward_limit());
 		YAF_EXCEPTION_HANDLE(dispatcher);
+		return NULL;
 	}
 }
 /* }}} */

--- a/yaf_response.c
+++ b/yaf_response.c
@@ -39,6 +39,13 @@ static zend_object_handlers yaf_response_obj_handlers;
 ZEND_BEGIN_ARG_INFO_EX(yaf_response_void_arginfo, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+#if PHP_VERSION_ID < 80100
+#define yaf_response_to_string_arginfo yaf_response_void_arginfo
+#else
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(yaf_response_to_string_arginfo, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
 ZEND_BEGIN_ARG_INFO_EX(yaf_response_get_body_arginfo, 0, 0, 0)
 	ZEND_ARG_INFO(0, name)
 ZEND_END_ARG_INFO()
@@ -558,7 +565,7 @@ PHP_METHOD(yaf_response, __toString) {
 */
 zend_function_entry yaf_response_methods[] = {
 	PHP_ME(yaf_response, __construct, yaf_response_void_arginfo,       ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
-	PHP_ME(yaf_response, __toString,  yaf_response_void_arginfo,                            ZEND_ACC_PUBLIC)
+	PHP_ME(yaf_response, __toString,  yaf_response_to_string_arginfo,  ZEND_ACC_PUBLIC)
 	PHP_ME(yaf_response, setBody,     yaf_response_set_body_arginfo,   ZEND_ACC_PUBLIC)
 	PHP_ME(yaf_response, appendBody,  yaf_response_set_body_arginfo,   ZEND_ACC_PUBLIC)
 	PHP_ME(yaf_response, prependBody, yaf_response_set_body_arginfo,   ZEND_ACC_PUBLIC)


### PR DESCRIPTION
```
/path/to/yaf/views/yaf_view_simple.c:415:63: error: too few arguments to function call, expected 3, have 2
        op_array = zend_compile_string(Z_STR(phtml), eval_desc);

/path/to/yaf/yaf.c:603:7: warning: expression result unused [-Wunused-value]
        for (idx; idx < sizeof(yaf_known_chars)/sizeof(char*) - 1; idx++) {

/path/to/yaf/yaf.c:53:12: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
const char const *yaf_known_chars[] = {

./php_yaf.h:157:19: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
extern const char const *yaf_known_chars[];

/path/to/yaf/routes/yaf_route_map.c:134:43: warning: passing 'unsigned char *' to parameter of type 'const char *' converts between pointers to integer types with different sign [-Wpointer-sign]
                zend_str_tolower_copy(ZSTR_VAL(result), str, end - str);


/path/to/yaf/yaf_dispatcher.c:826:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}

/path/to/yaf/routes/yaf_route_map.c:134:43: warning: passing 'unsigned char *' to parameter of type 'const char *' converts between pointers to integer types with different sign [-Wpointer-sign]
                zend_str_tolower_copy(ZSTR_VAL(result), str, end - str);


/path/to/yaf/routes/yaf_route_map.c:141:4: warning: expression result unused [-Wunused-value]
                        *p++, *q++;
                        ^~~~
/path/to/yaf/routes/yaf_route_map.c:141:10: warning: expression result unused [-Wunused-value]
                        *p++, *q++;
```

```
Warning: Yaf_Response_Abstract::__toString() implemented without string return type in Unknown on line 0
```