### PR TITLE
Fix PHP 8.2/8.3 compatibility

### DIFF
--- a/php_yaf.h
+++ b/php_yaf.h
@@ -260,6 +260,11 @@ static zend_always_inline uint32_t yaf_compose_2_pathes(char *buf, zend_string *
 }
 #endif
 
+/* removed in 8.3 */
+#ifndef ZEND_HOT
+#define ZEND_HOT
+#endif
+
 /*
  * Local variables:
  * tab-width: 4

--- a/php_yaf.h
+++ b/php_yaf.h
@@ -74,7 +74,11 @@ extern zend_module_entry yaf_module_entry;
 #else
 #define YAF_WRITE_HANDLER       zval *
 #define YAF_WHANDLER_RET(zv)    return zv
+#if PHP_VERSION_ID >= 80000
 HashTable *yaf_fake_get_gc(zend_object *zobj, zval **table, int *n);
+#else
+HashTable *yaf_fake_get_gc(zval *zobj, zval **table, int *n);
+#endif
 #endif
 
 #if PHP_VERSION_ID < 80000

--- a/requests/yaf_request_simple.c
+++ b/requests/yaf_request_simple.c
@@ -140,6 +140,9 @@ YAF_STARTUP_FUNCTION(request_simple){
 	zend_class_entry ce;
 	YAF_INIT_CLASS_ENTRY(ce, "Yaf_Request_Simple", "Yaf\\Request\\Simple", yaf_request_simple_methods);
 	yaf_request_simple_ce = zend_register_internal_class_ex(&ce, yaf_request_ce);
+#if PHP_VERSION_ID >= 80200
+	yaf_request_simple_ce->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+#endif
 
 	return SUCCESS;
 }

--- a/tests/031.phpt
+++ b/tests/031.phpt
@@ -36,7 +36,7 @@ Array
 )
 array (
   '_default' => 
-  Yaf_Route_Map::__set_state(array(
+  %saf_Route_Map::__set_state(array(
      'ctl_prefer:protected' => true,
      'delimiter:protected' => '##',
   )),

--- a/tests/issue231.phpt
+++ b/tests/issue231.phpt
@@ -34,7 +34,7 @@ Yaf_Request_Http Object
         )
 
 )
-Yaf_Request_Http::__set_state(array(
+%saf_Request_Http::__set_state(array(
    'method' => 'POST',
    'module' => NULL,
    'controller' => NULL,

--- a/views/yaf_view_simple.c
+++ b/views/yaf_view_simple.c
@@ -388,8 +388,10 @@ static int yaf_view_simple_eval(yaf_view_t *view, zend_string *tpl, zval * vars,
 		ZVAL_STR(&phtml, strpprintf(0, "?>%s", ZSTR_VAL(tpl)));
 #if PHP_VERSION_ID < 80000
 		op_array = zend_compile_string(&phtml, eval_desc);
-#else
+#elif PHP_VERSION_ID < 80200
         op_array = zend_compile_string(Z_STR(phtml), eval_desc);
+#else
+        op_array = zend_compile_string(Z_STR(phtml), eval_desc, ZEND_COMPILE_POSITION_AFTER_OPEN_TAG);
 #endif
 		zval_dtor(&phtml);
 		efree(eval_desc);

--- a/yaf.c
+++ b/yaf.c
@@ -72,7 +72,11 @@ void yaf_iterator_dtor(zend_object_iterator *iter) /* {{{ */ {
 /* }}} */
 
 #if PHP_VERSION_ID >= 70400
+#if PHP_VERSION_ID >= 80000
 HashTable *yaf_fake_get_gc(zend_object *zobj, zval **table, int *n) /* {{{ */ {
+#else
+HashTable *yaf_fake_get_gc(zval *zobj, zval **table, int *n) /* {{{ */ {
+#endif
 	*n = 0;
 	*table = NULL;
 	return NULL;

--- a/yaf_application.c
+++ b/yaf_application.c
@@ -1053,8 +1053,10 @@ YAF_STARTUP_FUNCTION(application) {
 	yaf_application_ce->ce_flags |= ZEND_ACC_FINAL;
 	yaf_application_ce->serialize = zend_class_serialize_deny;
 	yaf_application_ce->unserialize = zend_class_unserialize_deny;
-#else
+#elif PHP_VERSION_ID < 80200
 	yaf_application_ce->ce_flags |= ZEND_ACC_FINAL | ZEND_ACC_NOT_SERIALIZABLE;
+#else
+	yaf_application_ce->ce_flags |= ZEND_ACC_FINAL | ZEND_ACC_NOT_SERIALIZABLE | ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
 #endif
 
 	memcpy(&yaf_application_obj_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));


### PR DESCRIPTION
This proposal allow dynamic properties on some classes, as used in test suite

Perhaps this is needed for some other classes
Perhaps you will prefer to not allow them, so fix tests, of explicitly declare used properties.

Test suite passes:
```
=====================================================================
PHP         : /opt/remi/php82/root/usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.2.0RC2
ZEND_VERSION: 4.2.0RC2
PHP_OS      : Linux - Linux builder.remirepo.net 5.19.8-100.fc35.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Sep 8 19:23:03 UTC 2022 x86_64
INI actual  : /work/GIT/pecl-and-ext/yaf/tmp-php.ini
More .INIs  :  
---------------------------------------------------------------------
PHP         : /opt/remi/php82/root/usr/bin/php-cgi 
PHP_SAPI    : cgi-fcgi
PHP_VERSION : 8.2.0RC2
ZEND_VERSION: 4.2.0RC2
PHP_OS      : Linux - Linux builder.remirepo.net 5.19.8-100.fc35.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Sep 8 19:23:03 UTC 2022 x86_64
INI actual  : /work/GIT/pecl-and-ext/yaf/tmp-php.ini
More .INIs  : 
--------------------------------------------------------------------- 
CWD         : /work/GIT/pecl-and-ext/yaf
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2022-09-19 09:46:53
=====================================================================
PASS Check for yaf presence [tests/001.phpt] 
PASS Check for Yaf_Request_Simple [tests/002.phpt] 
PASS Check for Yaf_Loader local names [tests/003.phpt] 
PASS Check for Yaf_Registry APIs [tests/004.phpt] 
PASS Check for Yaf_Response_Cli APIs [tests/005.phpt] 
PASS Check for Yaf_Route_Static routing [tests/006.phpt] 
PASS Check for Yaf_Config_Simple APIs [tests/007.phpt] 
PASS Check for Yaf_Router basic usages [tests/008.phpt] 
PASS Check for Yaf_View_Simple basic usages [tests/009.phpt] 
PASS Check for Yaf_Config_Ini basic usages [tests/010.phpt] 
PASS Check for Yaf_Route_Rewrite routing [tests/011.phpt] 
PASS Check for Yaf_Route_Regex [tests/012.phpt] 
PASS Check for Yaf_Router and Config Routes [tests/013.phpt] 
PASS Check for Yaf_Application [tests/014.phpt] 
PASS Check for Yaf_Exception [tests/015.phpt] 
PASS Check for Yaf_Session [tests/016.phpt] 
PASS Bug (mem leak and crash in Yaf_Config_Ini) [tests/017.phpt] 
PASS Bug Yaf_Config_Ini crash due to inaccurate refcount [tests/018.phpt] 
PASS Yaf_Router::getCurrent with number key [tests/019.phpt] 
PASS Check for Yaf_Application errors variables [tests/020.phpt] 
PASS Check for Yaf_Application error handler [tests/021.phpt] 
PASS Check for Yaf_Application::get/setAppDirectory [tests/022.phpt] 
PASS Check for Yaf_Loader::set/get(library_path) [tests/023.phpt] 
PASS Check for Yaf_Loader::getInstace() paramters [tests/024.phpt] 
PASS Check for Yaf_Loader with namespace configuration [tests/025.phpt] 
PASS Check for Yaf_Response::setBody/prependBody/appendBody [tests/026.phpt] 
PASS Check for Yaf autoload controller [tests/027.phpt] 
SKIP Bug segfault while call exit in a view template [tests/028.phpt] 
PASS Check for Yaf_View_Simple::get and clear [tests/029.phpt] 
PASS Check for Yaf_Config_Ini::__construct with section [tests/030.phpt] 
PASS Check for application.dispatcher.defaultRoute [tests/031.phpt] 
PASS Check for Yaf_Config_Ini with env [tests/032.phpt] 
PASS Check for Yaf_View_Simple with predefined template dir [tests/033.phpt] 
PASS Check for Yaf_View_Simple::eval [tests/034.phpt] 
SKIP Check for Yaf_View_Simple with short_tag_open [tests/035.phpt] reason: PHP 5.4 remove short_open_tag
PASS Check for Yaf_Route_Static with arbitrary urls [tests/036.phpt] 
PASS Check for Yaf_Loader and open_basedir [tests/037.phpt] 
PASS Check for Yaf_View_Simple error message outputing [tests/038.phpt] 
PASS Check for Yaf_View_Simple recursive render error message outputing [tests/039.phpt] 
PASS Fixed bug that segv in Yaf_View_Simple::render if the tpl is not a string [tests/040.phpt] 
PASS Check for controller return false preventing auto-renderring [tests/041.phpt] 
PASS Check for throw exception in Yaf_Controller::init [tests/042.phpt] 
PASS Check for yaf.system settings [tests/043.phpt] 
PASS Memleaks in Yaf_Dispatcher::getInstance() [tests/044.phpt] 
PASS Check for segfault while use closure as error handler [tests/045.phpt] 
PASS Check for Yaf_Loader with single class [tests/046.phpt] 
PASS Check for Yaf_Loader with spl_autoload [tests/047.phpt] 
PASS Check for Sample application [tests/048.phpt] 
PASS Check for Sample application with exception [tests/049.phpt] 
PASS Check for Sample application with return response [tests/050.phpt] 
SKIP Fixed bug that segfault while a abnormal object set to Yaf_Route*::route [tests/051.phpt] 
PASS Check for Yaf_Request APis [tests/052.phpt] 
PASS Check for Custom view engine [tests/053.phpt] 
PASS check for Various segfault [tests/054.phpt] 
PASS check for Yaf_Dispatcher::autoRender [tests/055.phpt] 
PASS check for Yaf_Dispatcher::throwException [tests/056.phpt] 
PASS check for Yaf_Dispatcher::catchException [tests/057.phpt] 
PASS check for Yaf_Dispatcher::flushInstantly [tests/058.phpt] 
PASS Check nesting view render [tests/059.phpt] 
PASS Check for working with other autoloaders [tests/060.phpt] 
PASS Bug empty template file interrupts forward chain [tests/061.phpt] 
PASS Check for Yaf_View_Simple and application's template directory [tests/062.phpt] 
PASS Check for Yaf_Route_Rewrite with dynamic mvc [tests/063.phpt] 
PASS Check for Yaf_Route_Regex with dynamic mvc [tests/064.phpt] 
PASS Yaf_Route_Regex map is optional [tests/065.phpt] 
PASS Check for Yaf_Route_Regex with abnormal map [tests/066.phpt] 
PASS Check actions map with defined action class [tests/067.phpt] 
PASS Check for multi inheritance of section [tests/068.phpt] 
PASS Fixed bug that alter_response is not binary safe [tests/069.phpt] 
PASS Fixed misleading error message when providing a string in Yaf_Application construction [tests/070.phpt] 
PASS return type in Yaf_Simple_Config::valid() should be boolean [tests/071.phpt] 
PASS check for Yaf_Response_Http headers function; [tests/072.phpt] 
PASS Check for Yaf_Route_Rewrite::assemble [tests/073.phpt] 
PASS Check for Yaf_Route_Simple::assemble [tests/074.phpt] 
PASS Check for Yaf_Route_Regex::assemble [tests/075.phpt] 
PASS Check for Yaf_Route_Supervar::assemble [tests/076.phpt] 
PASS Check for Yaf_Route_Static::assemble [tests/077.phpt] 
PASS Check for Yaf_Route_Map::assemble [tests/078.phpt] 
PASS Autoloading the classes under library [tests/079.phpt] 
PASS PHP7 didn't display Error. [tests/080.phpt] 
PASS PHP7 Yaf_Response leak memory [tests/081.phpt] 
PASS Check for variables out of scope [tests/082.phpt] 
PASS Check for ReturnResponse in cli [tests/083.phpt] 
PASS Check request methods [tests/084.phpt] 
PASS Check Yaf_Request_Http::getRaw [tests/085.phpt] 
PASS Check for Yaf_Response_HTTP::setRedirect in CLI [tests/086.phpt] 
PASS Check for Yaf_Route_Map with arbitrary urls [tests/087.phpt] 
PASS Check for Yaf_Route_Rwrite with arbitrary urls [tests/088.phpt] 
PASS Check for Yaf_Config_Ini gets [tests/089.phpt] 
PASS Check for view path generating [tests/090.phpt] 
PASS Check for Yaf_Request_getXXX [tests/091.phpt] 
PASS Check for base uri detecting [tests/092.phpt] 
PASS Check for numeric keys in view assign [tests/093.phpt] 
PASS Check for Yaf_Request read/write property [tests/094.phpt] 
PASS Check for Yaf_Request read/write property [tests/095.phpt] 
PASS Check for Custom route [tests/096.phpt] 
PASS Check for Yaf_Route_Supervar with arbitrary urls [tests/097.phpt] 
PASS Check for Yaf_Bootstrap protected method [tests/098.phpt] 
PASS Check for Multiple exception in plugins [tests/099.phpt] 
PASS Check for error conditions of Yaf_Application::constructor [tests/100.phpt] 
PASS Check for various  cycle references [tests/101.phpt] 
PASS Check for yaf.forward_limit [tests/102.phpt] 
PASS Check for Yaf_Request::set*Name 's second argument [tests/103.phpt] 
PASS Check for Yaf_Dispatcher::dispatch() of errors while loading executor [tests/104.phpt] 
PASS Check for Yaf_Application::bootstrap errors [tests/105.phpt] 
PASS Check for PSR-4 autoloading [tests/106.phpt] 
PASS Check for Yaf_Dispatcher::setRespone [tests/107.phpt] 
PASS Check for auto response with ErrorController [tests/108.phpt] 
PASS Check for SIMD build_camel_name [tests/109.phpt] 
PASS Bug #61493 (Can't remove item when using unset() with a Yaf_Config_Simple instance) [tests/bug61493.phpt] 
PASS FR #62702 (Make baseuri case-insensitive) [tests/bug62702.phpt] 
PASS Bug #63381 ($_SERVER['SCRIPT_NAME'] changed by yaf) [tests/bug63381.phpt] 
PASS Bug #63438 (Strange behavior with nested rendering) [tests/bug63438.phpt] 
PASS Bug #63900 (Segfault if separated action executes failed) [tests/bug63900.phpt] 
PASS Bug #70913 (Segfault while new Yaf_Controller) [tests/bug70913.phpt] 
PASS Bug #76213 (Memory leaks with yaf_dispatcher_exception_handler) [tests/bug76213.phpt] 
PASS Bug #76217 (Memory leaks with Yaf_Dispatcher::setDefault*) [tests/bug76217.phpt] 
PASS ISSUE #134 (Segfault while calling assemble) [tests/issue134.phpt] 
PASS Issue #163 (forward from init controller) [tests/issue163.phpt] 
PASS ISSUE #231 (php-fpm worker core dump BUG) [tests/issue231.phpt] 
PASS ISSUE #232 (Segfault with Yaf_Route_Simple) [tests/issue232.phpt] 
PASS ISSUE #297 (Yaf_Loader fail to load namespace class name) [tests/issue297.phpt] 
PASS ISSUE #303 (local variable is overrided by view renderring) [tests/issue303.phpt] 
PASS ISSUE #311 (Yaf_application::environ should respect $environ) [tests/issue311.phpt] 
PASS Issue #415 ($actions changed to be reference) [tests/issue415.phpt] 
PASS Issue #420 (bug in yaf_dispatcher_get_call_parameters) [tests/issue420.phpt] 
PASS ISSUE #468 Check for same name variables assignment [tests/issue468.phpt] 
PASS Issue #469 (treat autocontroller as Contorller mistakenly) [tests/issue469.phpt] 
PASS Check for Custom MVC name [tests/issue513.phpt] 
PASS Check for Yaf_Response_HTTP::setRedirect in CGI [tests/issue518.phpt] 
PASS Segfault while exiting in action [tests/issue530.phpt] 
PASS ISSUE #535 (Segsev while throw exception in action) [tests/issue535.phpt] 
=====================================================================
TIME END 2022-09-19 09:46:55

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   17
---------------------------------------------------------------------

Number of tests :  132               129
Tests skipped   :    3 (  2.3%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :  129 ( 97.7%) (100.0%)
---------------------------------------------------------------------
Time taken      :    2 seconds
=====================================================================

```