### PR TITLE
open file not destroy or crash in Yaf_Config_Ini, PHP 8.1 or later

### DIFF
--- a/configs/yaf_config_ini.c
+++ b/configs/yaf_config_ini.c
@@ -81,7 +81,7 @@ static zval* yaf_config_ini_get(yaf_config_object *conf, zend_string *name) /* {
 	char *seg, *delim;
 	size_t len;
 	HashTable *target;
-	
+
 	if (conf->config == NULL) {
 		return NULL;
 	}
@@ -298,7 +298,7 @@ static void yaf_config_ini_parser_cb(zval *key, zval *value, zval *index, int ca
 			YAF_CONFIG_PARSER_FLAG() = YAF_CONFIG_INI_PARSING_END;
 			return;
 		}
-		
+
 		p = Z_STRVAL_P(key);
 		l = Z_STRLEN_P(key);
 
@@ -387,6 +387,9 @@ int yaf_config_ini_init(yaf_config_object *conf, zval *filename, zend_string *se
 						return 0;
 					}
 				}
+
+				// done
+				zend_destroy_file_handle(&fh);
 			} else {
 				yaf_trigger_error(E_ERROR, "Argument is not a valid ini file '%s'", ini_file);
 				return 0;

--- a/tests/110.phpt
+++ b/tests/110.phpt
@@ -13,7 +13,7 @@ $file = dirname(__FILE__) . "/simple.ini";
 // ulimit -n, default 256
 // open files will be 257
 for ($i = 0; $i < 257; $i++) {
-    $a = new Yaf\Config\Ini($file);
+    $a = new Yaf_Config_Ini($file);
     unset($a);
 }
 

--- a/tests/110.phpt
+++ b/tests/110.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug (mem leak or crash in Yaf_Config_Ini, PHP 8.1 or later)
+Bug (open file not destroy or crash in Yaf_Config_Ini, PHP 8.1 or later)
 --SKIPIF--
 <?php if (!extension_loaded("yaf")) print "skip"; ?>
 --INI--
@@ -10,7 +10,9 @@ yaf.use_namespace=0
 <?php
 $file = dirname(__FILE__) . "/simple.ini";
 
-for ($i = 0; $i < 10241; $i++) {
+// ulimit -n, default 256
+// open files will be 257
+for ($i = 0; $i < 257; $i++) {
     $a = new Yaf\Config\Ini($file);
     unset($a);
 }

--- a/tests/110.phpt
+++ b/tests/110.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug (mem leak or crash in Yaf_Config_Ini, PHP 8.1 or later)
+--SKIPIF--
+<?php if (!extension_loaded("yaf")) print "skip"; ?>
+--INI--
+yaf.use_spl_autoload=0
+yaf.lowcase_path=0
+yaf.use_namespace=0
+--FILE--
+<?php
+$file = dirname(__FILE__) . "/simple.ini";
+
+for ($i = 0; $i < 10241; $i++) {
+    $a = new Yaf\Config\Ini($file);
+    unset($a);
+}
+
+var_dump("Done")
+?>
+--EXPECTF--
+string(4) "Done"


### PR DESCRIPTION
Reported by [@fnu](https://github.com/fnu)

### the open files not destroyed:
![image](https://github.com/laruence/yaf/assets/5226315/41fac05b-c9c7-44fa-8184-a1cfebaa3b18)


### Affected API versions:
![image](https://github.com/laruence/yaf/assets/5226315/eabe1521-58c7-4fe2-8c95-fc306e69198f)
![image](https://github.com/laruence/yaf/assets/5226315/fe84354c-e186-41ed-b8f7-5543ddd3b7cf)

### Inspection Code (From: [@fnu](https://github.com/fnu)):

```
// Get the list of open files for the current PHP process
$command = 'lsof -p ' . getmypid() . ' | wc -l'; 

$outputStart = trim(shell_exec($command));

for ($i = 0; $i < 100; $i++) {
    $a = new Yaf\Config\Ini('../conf/redis.ini');
    unset($a);
}

// Manually trigger garbage collection
$collected = gc_collect_cycles(); 
sleep(1);

echo "Collected {$collected} variables.\n";
$outputEnd = trim(shell_exec($command));

$diff = intval($outputEnd) - intval($outputStart);

echo "Start: {$outputStart}, End: {$outputEnd}, Diff: {$diff}, Collected: {$collected};", PHP_EOL;

```

![image](https://github.com/laruence/yaf/assets/5226315/e4a4a910-cbdd-40a3-8531-79c00f6c6501)

