### PR TITLE
Fixes for PHP 8.4 and 8.5

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -56,7 +56,7 @@ if test "$PHP_YAF" != "no"; then
     routes/yaf_route_simple.c       \
     routes/yaf_route_supervar.c     \
     routes/yaf_route_regex.c        \
-    routes/yaf_route_rewrite.c      \ 
+    routes/yaf_route_rewrite.c      \
     routes/yaf_route_map.c          \
     yaf_loader.c                    \
     yaf_registry.c                  \

--- a/tests/038.phpt
+++ b/tests/038.phpt
@@ -34,4 +34,4 @@ require "build.inc";
 shutdown();
 ?>
 --EXPECTF--
-Parse error: syntax error, unexpected %s}%c in %sfoo.phtml on line %d
+Parse error: syntax error, unexpected %s in %sfoo.phtml on line %d

--- a/tests/039.phpt
+++ b/tests/039.phpt
@@ -45,4 +45,4 @@ require "build.inc";
 shutdown();
 ?>
 --EXPECTF--
-syntax error, unexpected %s}%c
+syntax error, unexpected %s

--- a/tests/104.phpt
+++ b/tests/104.phpt
@@ -174,4 +174,4 @@ string(%s) "Failed opening action script %sindex.php: No such file or directory"
 string(61) "Action 'IndexAction' is not a subclass of Yaf_Action_Abstract"
 string(61) "Action 'IndexAction' is not a subclass of Yaf_Action_Abstract"
 
-Fatal error: Class FooAction contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Yaf_Action_Abstract::execute) in %sfoo.php on line %d
+Fatal error: Class FooAction contains 1 abstract method and must therefore be declared abstract or implement the remaining method%s(Yaf_Action_Abstract::execute) in %sfoo.php on line %d

--- a/yaf_dispatcher.c
+++ b/yaf_dispatcher.c
@@ -21,7 +21,7 @@
 #include "php.h"
 #include "main/SAPI.h" /* for sapi_module */
 #include "Zend/zend_interfaces.h" /* for zend_call_method_with_* */
-#include "Zend/zend_exceptions.h" /* for zend_exception_get_default */
+#include "Zend/zend_exceptions.h" /* for zend_ce_exception */
 
 #include "php_yaf.h"
 #include "yaf_namespace.h"
@@ -355,7 +355,7 @@ static zend_class_entry *yaf_dispatcher_get_controller(zend_string *app_dir, yaf
 		directory_len += yaf_compose_2_pathes(directory + directory_len, module, ZEND_STRL(YAF_CONTROLLER_DIRECTORY_NAME));
 	}
 
-	STR_ALLOCA_ALLOC(lc_name, ZSTR_LEN(controller) + YAF_G(name_separator_len) + sizeof("controller") - 1, use_heap);
+	ZSTR_ALLOCA_ALLOC(lc_name, ZSTR_LEN(controller) + YAF_G(name_separator_len) + sizeof("controller") - 1, use_heap);
 	if (EXPECTED(yaf_is_name_suffix())) {
 		char *p = ZSTR_VAL(lc_name);
 		zend_str_tolower_copy(p, ZSTR_VAL(controller), ZSTR_LEN(controller));
@@ -381,15 +381,15 @@ static zend_class_entry *yaf_dispatcher_get_controller(zend_string *app_dir, yaf
 		if (yaf_loader_load_internal(l, ZSTR_VAL(controller), ZSTR_LEN(controller), directory, directory_len)) {
 			if (EXPECTED((ce = zend_hash_find_ptr(EG(class_table), lc_name)))) {
 				if (EXPECTED(instanceof_function(ce, yaf_controller_ce))) {
-					STR_ALLOCA_FREE(lc_name, use_heap);
+					ZSTR_ALLOCA_FREE(lc_name, use_heap);
 					return ce;
 				}
 			}
 		}
-		STR_ALLOCA_FREE(lc_name, use_heap);
+		ZSTR_ALLOCA_FREE(lc_name, use_heap);
 		return yaf_dispatcher_get_errors_hub(1, ce, controller, directory, directory_len);
 	}
-	STR_ALLOCA_FREE(lc_name, use_heap);
+	ZSTR_ALLOCA_FREE(lc_name, use_heap);
 	return ce;
 }
 /* }}} */
@@ -417,7 +417,7 @@ static zend_class_entry *yaf_dispatcher_get_action(zend_string *app_dir, yaf_con
 		zend_string *lc_name;
 		ALLOCA_FLAG(use_heap);
 
-		STR_ALLOCA_ALLOC(lc_name, ZSTR_LEN(action) + YAF_G(name_separator_len) + sizeof("action") - 1, use_heap);
+		ZSTR_ALLOCA_ALLOC(lc_name, ZSTR_LEN(action) + YAF_G(name_separator_len) + sizeof("action") - 1, use_heap);
 		if (EXPECTED(yaf_is_name_suffix())) {
 			char *p = ZSTR_VAL(lc_name);
 			memcpy(p, ZSTR_VAL(action), ZSTR_LEN(action));
@@ -440,7 +440,7 @@ static zend_class_entry *yaf_dispatcher_get_action(zend_string *app_dir, yaf_con
 
 		if ((ce = zend_hash_find_ptr(EG(class_table), lc_name)) != NULL) {
 			if (EXPECTED(instanceof_function(ce, yaf_action_ce))) {
-				STR_ALLOCA_FREE(lc_name, use_heap);
+				ZSTR_ALLOCA_FREE(lc_name, use_heap);
 				return ce;
 			}
 		} else if (((pzval = zend_hash_find_ind(Z_ARRVAL_P(actions_map), action)) != NULL) &&
@@ -453,13 +453,13 @@ static zend_class_entry *yaf_dispatcher_get_action(zend_string *app_dir, yaf_con
 			if (yaf_loader_import(path, len)) {
 				if ((ce = zend_hash_find_ptr(EG(class_table), lc_name)) != NULL) {
 					if (EXPECTED(instanceof_function(ce, yaf_action_ce))) {
-						STR_ALLOCA_FREE(lc_name, use_heap);
+						ZSTR_ALLOCA_FREE(lc_name, use_heap);
 						return ce;
 					}
 				}
 			}
 		}
-		STR_ALLOCA_FREE(lc_name, use_heap);
+		ZSTR_ALLOCA_FREE(lc_name, use_heap);
 	}
 
 	return yaf_dispatcher_get_errors_hub(2, ce, actions_map, action, controller, path);

--- a/yaf_exception.c
+++ b/yaf_exception.c
@@ -73,7 +73,7 @@ zend_class_entry * yaf_get_exception_base(int root) /* {{{ */ {
 	}
 #endif
 
-	return zend_exception_get_default();
+	return zend_ce_exception;
 }
 /* }}} */
 

--- a/yaf_request.c
+++ b/yaf_request.c
@@ -21,7 +21,7 @@
 #include "php.h"
 #include "main/SAPI.h"
 #include "standard/php_string.h" /* for php_basename */
-#include "Zend/zend_exceptions.h" /* for zend_exception_get_default */
+#include "Zend/zend_exceptions.h" /* for zend_ce_exception */
 #include "Zend/zend_interfaces.h" /* for zend_class_serialize_deny */
 #include "Zend/zend_smart_str.h"
 


### PR DESCRIPTION
Because of this, build is strangely failing (8.4 only)

`make[1]: *** No rule to make target 'routes/yaf_route_map.c', needed by 'routes/yaf_route_map.lo'.  Stop.`

In Makefile.objects (notice the space in the path)

`Makefile: routes/yaf_route_map.lo: /builddir/build/BUILD/php-pecl-yaf-3.3.6-build/php-pecl-yaf-3.3.6/yaf-3.3.6/ routes/yaf_route_map.c`